### PR TITLE
Add GitHub Actions context to connection logs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@
 
 ## Medium Priority
 
-- [ ] Collect GitHub job step info from process env for the log
+- [x] Collect GitHub job step info from process env for the log
 - [ ] Investigate UDP fast path using eBPF TC to mark allowed packets based on 4-tuple and skip nfqueue
 
 ## Low Priority

--- a/src/proxy/main.py
+++ b/src/proxy/main.py
@@ -101,8 +101,40 @@ if VERBOSE:
         mlog.addHandler(_mitmproxy_handler)
 
 
+def get_github_step(pid: int) -> str | None:
+    """Get GitHub Actions step identifier by walking up the process tree."""
+    visited = set()
+    while pid and pid > 1 and pid not in visited:
+        visited.add(pid)
+        try:
+            environ = Path(f"/proc/{pid}/environ").read_bytes()
+            # Fast check before parsing
+            if b"GITHUB_JOB" not in environ:
+                pass  # Fall through to get parent
+            else:
+                env_vars = dict(
+                    kv.split(b"=", 1) for kv in environ.split(b"\x00")
+                    if b"=" in kv
+                )
+                job = env_vars.get(b"GITHUB_JOB", b"").decode("utf-8", errors="replace")
+                action = env_vars.get(b"GITHUB_ACTION", b"").decode("utf-8", errors="replace")
+                if job and action:
+                    return f"{job}.{action}"
+            # Get parent PID from /proc/{pid}/status
+            status = Path(f"/proc/{pid}/status").read_text()
+            for line in status.splitlines():
+                if line.startswith("PPid:"):
+                    pid = int(line.split()[1])
+                    break
+            else:
+                break
+        except (OSError, FileNotFoundError, ValueError):
+            break
+    return None
+
+
 def get_proc_info(pid: int | None) -> dict:
-    """Get process info from /proc: exe, cmdline."""
+    """Get process info from /proc: exe, cmdline, GitHub Actions step."""
     if not pid:
         return {}
     result = {}
@@ -117,6 +149,9 @@ def get_proc_info(pid: int | None) -> dict:
             result["cmdline"] = [arg.decode("utf-8", errors="replace") for arg in cmdline.rstrip(b"\x00").split(b"\x00")]
     except (OSError, FileNotFoundError):
         pass
+    step = get_github_step(pid)
+    if step:
+        result["step"] = step
     return result
 
 


### PR DESCRIPTION
## Summary
- Read `GITHUB_JOB` and `GITHUB_ACTION` from process environ
- Include as `step` field (dot-separated: `job.action`)
- Allows identifying which job/step made each network connection

Example output:
```json
{"ts":"...","type":"http","dst_ip":"140.82.116.3","url":"https://github.com/...","exe":"/usr/lib/git-core/git-remote-http","cmdline":[...],"step":"test.__actions_checkout","src_port":42736,"pid":2185}
```

## Test plan
- [x] Workflow passes
- [x] Connection events show `step` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)