### PR TITLE
Add action= attribute to scope rules to GitHub Actions

### DIFF
--- a/src/proxy/policy/enforcer.py
+++ b/src/proxy/policy/enforcer.py
@@ -71,6 +71,7 @@ class ProcessInfo:
     cmdline: list[str] | None = None
     cgroup: str | None = None
     step: str | None = None
+    action: str | None = None
 
     @classmethod
     def from_dict(cls, d: dict) -> "ProcessInfo":
@@ -80,6 +81,7 @@ class ProcessInfo:
             cmdline=d.get("cmdline"),
             cgroup=d.get("cgroup"),
             step=d.get("step"),
+            action=d.get("action"),
         )
 
     def to_dict(self) -> dict:
@@ -93,6 +95,8 @@ class ProcessInfo:
             result["cgroup"] = self.cgroup
         if self.step:
             result["step"] = self.step
+        if self.action:
+            result["action"] = self.action
         return result
 
 

--- a/src/proxy/policy/matcher.py
+++ b/src/proxy/policy/matcher.py
@@ -27,6 +27,7 @@ class ConnectionEvent:
     cmdline: list[str] | None = None
     cgroup: str | None = None
     step: str | None = None
+    action: str | None = None  # GitHub Action repository (e.g., "actions/checkout")
 
     @classmethod
     def from_dict(cls, data: dict) -> "ConnectionEvent":
@@ -43,6 +44,7 @@ class ConnectionEvent:
             cmdline=data.get("cmdline"),
             cgroup=data.get("cgroup"),
             step=data.get("step"),
+            action=data.get("action"),
         )
 
 
@@ -246,6 +248,14 @@ def match_attrs(rule: Rule, event: ConnectionEvent) -> bool:
             if event.step is None:
                 return False
             if not match_attr_value(value, event.step):
+                return False
+            continue
+
+        # Handle action (GitHub Action repository, e.g., "actions/checkout")
+        if key == "action":
+            if event.action is None:
+                return False
+            if not match_attr_value(value, event.action):
                 return False
             continue
 

--- a/tests/fixtures/policy_match.yaml
+++ b/tests/fixtures/policy_match.yaml
@@ -712,6 +712,57 @@ tests:
           host: github.com
         verdict: block
 
+  - name: Action attribute exact match
+    policy: |
+      github.com action=actions/checkout
+    connections:
+      - event:
+          type: https
+          dst_ip: 140.82.121.4
+          dst_port: 443
+          host: github.com
+          action: actions/checkout
+        verdict: allow
+      - event:
+          type: https
+          dst_ip: 140.82.121.4
+          dst_port: 443
+          host: github.com
+          action: actions/setup-node
+        verdict: block
+      - event:
+          type: https
+          dst_ip: 140.82.121.4
+          dst_port: 443
+          host: github.com
+        verdict: block
+
+  - name: Action attribute wildcard match
+    policy: |
+      github.com action=actions/*
+    connections:
+      - event:
+          type: https
+          dst_ip: 140.82.121.4
+          dst_port: 443
+          host: github.com
+          action: actions/checkout
+        verdict: allow
+      - event:
+          type: https
+          dst_ip: 140.82.121.4
+          dst_port: 443
+          host: github.com
+          action: actions/setup-node
+        verdict: allow
+      - event:
+          type: https
+          dst_ip: 140.82.121.4
+          dst_port: 443
+          host: github.com
+          action: docker/build-push-action
+        verdict: block
+
   - name: Cgroup attribute with abstraction
     policy: |
       github.com cgroup=@docker


### PR DESCRIPTION
## Summary

Add support for matching connections by the GitHub Action repository (e.g., `actions/checkout`) via `GITHUB_ACTION_REPOSITORY` env var. This is more reliable than `step=` which can be overridden by custom step ids.

## Changes

- **proc.py**: Add `get_github_action_repo()` that walks up process tree looking for `GITHUB_ACTION_REPOSITORY`
- **enforcer.py**: Add `action` field to `ProcessInfo`
- **matcher.py**: Add `action` field to `ConnectionEvent` and matching logic in `match_attrs()`
- **tests**: Add test cases for exact and wildcard matching

## Usage

```yaml
policy: |
  # Only actions/checkout can access github.com
  [action=actions/checkout]
  github.com
  
  # Any docker org action
  [action=docker/*]
  *.docker.io
```

## Test plan

- [x] Existing tests pass (246 passed)
- [x] New test cases for `action=` exact match
- [x] New test cases for `action=` wildcard match (e.g., `actions/*`)

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)