### PR TITLE
fix: use env-based GITHUB_ACTION for control server verification

### DIFF
--- a/dist/pre/index.js
+++ b/dist/pre/index.js
@@ -85853,6 +85853,7 @@ async function run() {
       `PATH=${process.env.PATH}`,
       `GITHUB_ENV=${process.env.GITHUB_ENV}`,
       `GITHUB_REPOSITORY=${process.env.GITHUB_REPOSITORY || ''}`,
+      `GITHUB_ACTION=${process.env.GITHUB_ACTION || ''}`,
       `EGRESS_FILTER_ROOT=${actionPath}`,
       `EGRESS_POLICY_FILE=${policyFile}`,
       `EGRESS_AUDIT_MODE=${audit ? '1' : '0'}`,

--- a/src/action/pre.js
+++ b/src/action/pre.js
@@ -97,6 +97,7 @@ async function run() {
       `PATH=${process.env.PATH}`,
       `GITHUB_ENV=${process.env.GITHUB_ENV}`,
       `GITHUB_REPOSITORY=${process.env.GITHUB_REPOSITORY || ''}`,
+      `GITHUB_ACTION=${process.env.GITHUB_ACTION || ''}`,
       `EGRESS_FILTER_ROOT=${actionPath}`,
       `EGRESS_POLICY_FILE=${policyFile}`,
       `EGRESS_AUDIT_MODE=${audit ? '1' : '0'}`,

--- a/src/proxy/control.py
+++ b/src/proxy/control.py
@@ -10,7 +10,7 @@ it can't use normal mechanisms. This Unix socket provides authenticated shutdown
    - parent exe: /home/runner/actions-runner/cached/bin/Runner.Worker
    - cgroup: 0::/system.slice/hosted-compute-agent.service
    - exe: /home/runner/actions-runner/cached/externals/node24/bin/node
-   - GITHUB_ACTION: __gregclermont_egress-filter
+   - GITHUB_ACTION: matches value passed from pre-hook (supports custom step ids)
    - cmdline: contains "egress-filter" (path varies)
 4. If verified, proxy initiates graceful shutdown
 
@@ -44,8 +44,10 @@ EXPECTED_CGROUP = "0::/system.slice/hosted-compute-agent.service"
 # Node exe - exact path, must match 'using' in action.yml (currently node24)
 EXPECTED_EXE = "/home/runner/actions-runner/cached/externals/node24/bin/node"
 
-# GITHUB_ACTION format: __<owner>_<repo>
-EXPECTED_GITHUB_ACTION = "__gregclermont_egress-filter"
+# GITHUB_ACTION is passed from pre-hook via environment.
+# Format varies: __<owner>_<repo> for default step id, or custom id if user specifies one.
+# Captured at startup so post-hook verification uses the same value.
+EXPECTED_GITHUB_ACTION = os.environ.get("GITHUB_ACTION", "")
 
 # Cmdline can vary based on action path, but must contain our action
 EXPECTED_CMDLINE_PATTERNS = [


### PR DESCRIPTION
## Summary

- Pass `GITHUB_ACTION` from pre-hook to proxy via environment variable
- Replace hardcoded `EXPECTED_GITHUB_ACTION` with value from environment
- Update docstring to reflect the change

This fixes control server verification failures when users specify custom step ids in their workflow (e.g., `id: my-custom-id`), since `GITHUB_ACTION` reflects the custom id rather than the default `__owner_repo` format.

Fixes #13

## Test plan

- [ ] Run workflow with default step id (no `id:` specified) - verify shutdown works
- [ ] Run workflow with custom step id (`id: custom-name`) - verify shutdown works

🤖 Generated with [Claude Code](https://claude.com/claude-code)