### PR TITLE
feat: support IP addresses in URL rules

### DIFF
--- a/tests/fixtures/policy_flatten.yaml
+++ b/tests/fixtures/policy_flatten.yaml
@@ -197,6 +197,70 @@ tests:
         attrs: {}
 
   # =============================================================================
+  # URL rules with IP addresses
+  # =============================================================================
+
+  - name: URL with IP address (HTTP)
+    policy: |
+      http://168.63.129.16/*
+    rules:
+      - type: url
+        target: http://168.63.129.16/*
+        port: [80]
+        protocol: tcp
+        methods: ["GET", "HEAD"]
+        url_base: null
+        attrs: {}
+
+  - name: URL with IP address and port
+    policy: |
+      http://168.63.129.16:8080/api/*
+    rules:
+      - type: url
+        target: http://168.63.129.16:8080/api/*
+        port: [8080]
+        protocol: tcp
+        methods: ["GET", "HEAD"]
+        url_base: null
+        attrs: {}
+
+  - name: URL with IP address and explicit method
+    policy: |
+      POST http://192.168.1.1/submit
+    rules:
+      - type: url
+        target: http://192.168.1.1/submit
+        port: [80]
+        protocol: tcp
+        methods: ["POST"]
+        url_base: null
+        attrs: {}
+
+  - name: URL with IP address and any method
+    policy: |
+      * http://10.0.0.1/api/*
+    rules:
+      - type: url
+        target: http://10.0.0.1/api/*
+        port: [80]
+        protocol: tcp
+        methods: ["*"]
+        url_base: null
+        attrs: {}
+
+  - name: URL with IP address HTTPS
+    policy: |
+      https://192.168.0.1/secure/*
+    rules:
+      - type: url
+        target: https://192.168.0.1/secure/*
+        port: [443]
+        protocol: tcp
+        methods: ["GET", "HEAD"]
+        url_base: null
+        attrs: {}
+
+  # =============================================================================
   # Headers - port and protocol defaults
   # =============================================================================
 
@@ -497,6 +561,40 @@ tests:
         protocol: tcp
         methods: ["GET", "HEAD"]
         url_base: https://api.github.com
+        attrs: {}
+
+  - name: URL base header with IP address
+    policy: |
+      [http://168.63.129.16]
+      GET /machine
+      POST /health
+    rules:
+      - type: path
+        target: /machine
+        port: [80]
+        protocol: tcp
+        methods: ["GET"]
+        url_base: http://168.63.129.16
+        attrs: {}
+      - type: path
+        target: /health
+        port: [80]
+        protocol: tcp
+        methods: ["POST"]
+        url_base: http://168.63.129.16
+        attrs: {}
+
+  - name: URL base header with IP address and port
+    policy: |
+      [http://168.63.129.16:32526]
+      * /*
+    rules:
+      - type: path
+        target: /*
+        port: [32526]
+        protocol: tcp
+        methods: ["*"]
+        url_base: http://168.63.129.16:32526
         attrs: {}
 
   # =============================================================================

--- a/tests/fixtures/policy_match.yaml
+++ b/tests/fixtures/policy_match.yaml
@@ -415,6 +415,204 @@ tests:
         verdict: block
 
   # =============================================================================
+  # URL rules with IP addresses
+  # =============================================================================
+
+  - name: URL with IP address matches HTTP request to IP
+    policy: |
+      http://168.63.129.16/*
+    connections:
+      - event:
+          type: http
+          dst_ip: 168.63.129.16
+          dst_port: 80
+          url: http://168.63.129.16/machine
+        verdict: allow
+      - event:
+          type: http
+          dst_ip: 168.63.129.16
+          dst_port: 80
+          url: http://168.63.129.16/health
+        verdict: allow
+      # Different IP - should not match
+      - event:
+          type: http
+          dst_ip: 10.0.0.1
+          dst_port: 80
+          url: http://10.0.0.1/machine
+        verdict: block
+
+  - name: URL with IP address does NOT match hostname-based request
+    policy: |
+      http://168.63.129.16/*
+    connections:
+      # Even if example.com resolves to 168.63.129.16, URL matching is string-based
+      - event:
+          type: http
+          dst_ip: 168.63.129.16
+          dst_port: 80
+          url: http://example.com/api
+        verdict: block
+
+  - name: URL with IP address and explicit port
+    policy: |
+      http://168.63.129.16:32526/*
+    connections:
+      - event:
+          type: http
+          dst_ip: 168.63.129.16
+          dst_port: 32526
+          url: http://168.63.129.16:32526/health
+        verdict: allow
+      # Wrong port in URL - should not match
+      - event:
+          type: http
+          dst_ip: 168.63.129.16
+          dst_port: 80
+          url: http://168.63.129.16/health
+        verdict: block
+
+  - name: URL with IP address and method restriction
+    policy: |
+      POST http://192.168.1.1/api/submit
+    connections:
+      - event:
+          type: http
+          dst_ip: 192.168.1.1
+          dst_port: 80
+          url: http://192.168.1.1/api/submit
+          method: POST
+        verdict: allow
+      - event:
+          type: http
+          dst_ip: 192.168.1.1
+          dst_port: 80
+          url: http://192.168.1.1/api/submit
+          method: GET
+        verdict: block
+
+  - name: URL with IP address and any method
+    policy: |
+      * http://10.0.0.1/api/*
+    connections:
+      - event:
+          type: http
+          dst_ip: 10.0.0.1
+          dst_port: 80
+          url: http://10.0.0.1/api/users
+          method: GET
+        verdict: allow
+      - event:
+          type: http
+          dst_ip: 10.0.0.1
+          dst_port: 80
+          url: http://10.0.0.1/api/users
+          method: POST
+        verdict: allow
+      - event:
+          type: http
+          dst_ip: 10.0.0.1
+          dst_port: 80
+          url: http://10.0.0.1/api/users
+          method: DELETE
+        verdict: allow
+
+  - name: IP address network rule still matches HTTP at TCP level
+    policy: |
+      168.63.129.16:80
+    connections:
+      # Network rules match based on IP/port, regardless of URL content
+      - event:
+          type: http
+          dst_ip: 168.63.129.16
+          dst_port: 80
+          url: http://168.63.129.16/anything
+        verdict: allow
+      - event:
+          type: http
+          dst_ip: 168.63.129.16
+          dst_port: 80
+          url: http://example.com/anything
+        verdict: allow
+
+  # =============================================================================
+  # IP vs hostname URL matching - safeguards against crossover
+  # =============================================================================
+
+  - name: Hostname URL rule does NOT match IP-based request (even same IP)
+    policy: |
+      http://example.com/*
+    connections:
+      # Hostname-based rule should not match request with IP in URL
+      # even if the IP is what example.com resolves to
+      - event:
+          type: http
+          dst_ip: 93.184.216.34
+          dst_port: 80
+          url: http://93.184.216.34/path
+        verdict: block
+      # But should match hostname-based request
+      - event:
+          type: http
+          dst_ip: 93.184.216.34
+          dst_port: 80
+          url: http://example.com/path
+        verdict: allow
+
+  - name: IP URL rule does NOT match hostname-based request (strict string match)
+    policy: |
+      http://93.184.216.34/*
+    connections:
+      # IP-based rule should not match request with hostname in URL
+      - event:
+          type: http
+          dst_ip: 93.184.216.34
+          dst_port: 80
+          url: http://example.com/path
+        verdict: block
+      # But should match IP-based request
+      - event:
+          type: http
+          dst_ip: 93.184.216.34
+          dst_port: 80
+          url: http://93.184.216.34/path
+        verdict: allow
+
+  - name: Mixed policy with both IP and hostname rules
+    policy: |
+      http://168.63.129.16/*
+      http://example.com/*
+    connections:
+      # IP rule matches IP request
+      - event:
+          type: http
+          dst_ip: 168.63.129.16
+          dst_port: 80
+          url: http://168.63.129.16/api
+        verdict: allow
+      # Hostname rule matches hostname request
+      - event:
+          type: http
+          dst_ip: 93.184.216.34
+          dst_port: 80
+          url: http://example.com/api
+        verdict: allow
+      # No crossover - hostname request to IP address
+      - event:
+          type: http
+          dst_ip: 168.63.129.16
+          dst_port: 80
+          url: http://wireserver.local/api
+        verdict: block
+      # No crossover - IP request when only hostname rule exists
+      - event:
+          type: http
+          dst_ip: 93.184.216.34
+          dst_port: 80
+          url: http://93.184.216.34/api
+        verdict: block
+
+  # =============================================================================
   # HTTP method matching
   # =============================================================================
 


### PR DESCRIPTION
## Summary

Extends the policy grammar to allow IP addresses in URL rules, enabling URL-level granularity (paths, methods) for requests to IP addresses.

**Before:** Users had to use network rules for IP addresses, which only match at TCP level:
```yaml
# Only allowed TCP to this IP on port 80 - no path control
168.63.129.16:80
```

**After:** Full URL rule syntax works with IP addresses:
```yaml
# Path and method control for IP-based requests
GET http://168.63.129.16/api/*
POST http://168.63.129.16:32526/health
* http://10.0.0.1:8080/*

# Header context also works
[http://168.63.129.16:32526]
POST /health
GET /status
```

## Changes

- Add `url_host = ipv4 / hostname` to grammar
- Update `url_rule` and `url_base` to use `url_host`
- Extract explicit ports from URL base headers
- Add comprehensive tests including safeguards against IP/hostname crossover

## Safeguards

URL matching is strictly string-based:
- `http://168.63.129.16/*` only matches requests with `168.63.129.16` in the URL
- It does NOT match `http://example.com/*` even if example.com resolves to 168.63.129.16

This prevents accidental permission escalation via DNS.

Closes #21

## Test plan

- [x] 28 new tests added (504 total, all passing)
- [ ] Push to `test` branch to verify in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)