### PR TITLE
feat: support prefix wildcards in hostname patterns

### DIFF
--- a/tests/fixtures/policy_flatten.yaml
+++ b/tests/fixtures/policy_flatten.yaml
@@ -37,7 +37,7 @@ tests:
       *.github.com
     rules:
       - type: wildcard_host
-        target: github.com
+        target: "*.github.com"
         port: [443]
         protocol: tcp
         methods: null
@@ -793,7 +793,7 @@ tests:
             value: "/usr/lib/git-core/git-remote-*"
             literal: false
       - type: wildcard_host
-        target: github.com
+        target: "*.github.com"
         port: [443]
         protocol: tcp
         methods: null
@@ -1011,7 +1011,7 @@ tests:
         url_base: null
         attrs: {}
       - type: wildcard_host
-        target: npmjs.org
+        target: "*.npmjs.org"
         port: [443]
         protocol: tcp
         methods: null

--- a/tests/fixtures/policy_match.yaml
+++ b/tests/fixtures/policy_match.yaml
@@ -95,6 +95,105 @@ tests:
           host: GITHUB.COM
         verdict: allow
 
+  - name: Label wildcard match (fnmatch in first label)
+    policy: |
+      derp*.tailscale.com
+    connections:
+      - event:
+          type: https
+          dst_ip: 1.2.3.4
+          dst_port: 443
+          host: derp1.tailscale.com
+        verdict: allow
+      - event:
+          type: https
+          dst_ip: 1.2.3.4
+          dst_port: 443
+          host: derp2f.tailscale.com
+        verdict: allow
+      - event:
+          type: https
+          dst_ip: 1.2.3.4
+          dst_port: 443
+          host: derp.tailscale.com
+        verdict: allow
+      # Does not match with extra subdomains
+      - event:
+          type: https
+          dst_ip: 1.2.3.4
+          dst_port: 443
+          host: foo.derp1.tailscale.com
+        verdict: block
+      # Does not match base domain
+      - event:
+          type: https
+          dst_ip: 1.2.3.4
+          dst_port: 443
+          host: tailscale.com
+        verdict: block
+      # Does not match wrong prefix
+      - event:
+          type: https
+          dst_ip: 1.2.3.4
+          dst_port: 443
+          host: api.tailscale.com
+        verdict: block
+
+  - name: Subdomain + label wildcard match
+    policy: |
+      *.derp*.tailscale.com
+    connections:
+      # Matches with extra subdomain
+      - event:
+          type: https
+          dst_ip: 1.2.3.4
+          dst_port: 443
+          host: foo.derp1.tailscale.com
+        verdict: allow
+      - event:
+          type: https
+          dst_ip: 1.2.3.4
+          dst_port: 443
+          host: a.b.derp2.tailscale.com
+        verdict: allow
+      # Does not match without extra subdomain
+      - event:
+          type: https
+          dst_ip: 1.2.3.4
+          dst_port: 443
+          host: derp1.tailscale.com
+        verdict: block
+      # Does not match wrong label
+      - event:
+          type: https
+          dst_ip: 1.2.3.4
+          dst_port: 443
+          host: foo.api.tailscale.com
+        verdict: block
+
+  - name: Suffix wildcard pattern
+    policy: |
+      *-prod.example.com
+    connections:
+      - event:
+          type: https
+          dst_ip: 1.2.3.4
+          dst_port: 443
+          host: api-prod.example.com
+        verdict: allow
+      - event:
+          type: https
+          dst_ip: 1.2.3.4
+          dst_port: 443
+          host: web-prod.example.com
+        verdict: allow
+      - event:
+          type: https
+          dst_ip: 1.2.3.4
+          dst_port: 443
+          host: api-dev.example.com
+        verdict: block
+
   # =============================================================================
   # IP and CIDR matching
   # =============================================================================

--- a/tests/test_policy_cli.py
+++ b/tests/test_policy_cli.py
@@ -373,7 +373,7 @@ class TestDumpRules:
 
         # Second rule: wildcard host
         assert dumped[1]["type"] == "wildcard_host"
-        assert dumped[1]["target"] == "github.com"
+        assert dumped[1]["target"] == "*.github.com"
 
         # Third rule: IP with UDP
         assert dumped[2]["type"] == "ip"

--- a/tests/test_policy_properties.py
+++ b/tests/test_policy_properties.py
@@ -231,7 +231,9 @@ class TestHostnameProperties:
         assume(len(base_host) > 3)
         assume(len(subdomain) > 0)
         full_host = f"{subdomain}.{base_host}"
-        assert match_hostname(base_host, full_host, is_wildcard=True)
+        # Pattern must include *. prefix for subdomain wildcard
+        pattern = f"*.{base_host}"
+        assert match_hostname(pattern, full_host, is_wildcard=True)
 
     @given(hostname())
     @settings(max_examples=200, suppress_health_check=[HealthCheck.filter_too_much])
@@ -239,7 +241,8 @@ class TestHostnameProperties:
         """Wildcard pattern does NOT match the root domain itself."""
         assume(len(host) > 3)
         # *.example.com should NOT match example.com
-        assert not match_hostname(host, host, is_wildcard=True)
+        pattern = f"*.{host}"
+        assert not match_hostname(pattern, host, is_wildcard=True)
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Add support for wildcard patterns (`*`) in the first label of hostname rules
- Support optional `*.` prefix for subdomain depth matching
- Store full pattern in rule target (e.g., `*.github.com` instead of stripped `github.com`)

## Pattern Examples

| Pattern | Matches | Doesn't match |
|---------|---------|---------------|
| `tailscale.com` | `tailscale.com` | `derp1.tailscale.com` |
| `*.tailscale.com` | `derp1.tailscale.com`, `a.b.tailscale.com` | `tailscale.com` |
| `derp*.tailscale.com` | `derp1.tailscale.com`, `derp2f.tailscale.com` | `foo.derp1.tailscale.com` |
| `*.derp*.tailscale.com` | `foo.derp1.tailscale.com`, `a.b.derp1.tailscale.com` | `derp1.tailscale.com` |

## Test plan

- [x] All 525 tests pass
- [x] New grammar tests for valid patterns: `derp*.tailscale.com`, `*.derp*.tailscale.com`, `*-prod.example.com`
- [x] New grammar tests for invalid patterns: `api.derp*.example.com` (wildcard not in first label)
- [x] New match tests for label wildcards and subdomain+label wildcards
- [x] Updated property tests and fixture expectations for new target format

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)