### PR TITLE
feat: add proxy supervisor with automatic restart capability

### DIFF
--- a/.github/workflows/test-proxy-restart.yml
+++ b/.github/workflows/test-proxy-restart.yml
@@ -1,0 +1,75 @@
+name: Test proxy restart
+
+on:
+  push:
+    branches: [test]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-restart:
+    name: Restart test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Setup egress filter
+        uses: gregclermont/egress-filter@test
+        with:
+          allow-sudo: true
+          audit: true
+          policy: |
+            example.com
+            [:53/udp]
+
+      - name: Test proxy restart
+        run: |
+          set -x
+
+          # Initial state
+          INITIAL_PID=$(cat /tmp/proxy.pid)
+          echo "Initial proxy PID: $INITIAL_PID"
+
+          # Verify it works
+          curl -sf https://example.com -o /dev/null
+          echo "Initial connection OK"
+
+          # Kill proxy
+          sudo kill -9 "$INITIAL_PID"
+
+          # Wait for restart
+          for i in {1..30}; do
+            NEW_PID=$(cat /tmp/proxy.pid 2>/dev/null || echo "$INITIAL_PID")
+            if [ "$NEW_PID" != "$INITIAL_PID" ]; then
+              echo "Proxy restarted with PID $NEW_PID"
+              break
+            fi
+            sleep 0.5
+          done
+
+          if [ "$NEW_PID" = "$INITIAL_PID" ]; then
+            echo "ERROR: Proxy did not restart"
+            exit 1
+          fi
+
+          # Wait for proxy to be ready
+          sleep 2
+
+          # Test connectivity after restart
+          curl -sf https://example.com -o /dev/null && echo "HTTPS OK" || {
+            echo "HTTPS FAILED"
+            exit 1
+          }
+
+          echo "SUCCESS"
+
+      - name: Show logs
+        if: always()
+        run: |
+          echo "=== Supervisor log ==="
+          cat /tmp/proxy-stdout.log || true
+          echo ""
+          echo "=== Proxy log (last 50 lines) ==="
+          tail -50 /tmp/proxy.log || true

--- a/src/proxy/main.py
+++ b/src/proxy/main.py
@@ -175,7 +175,7 @@ async def async_main():
     if policy_file and os.path.exists(policy_file):
         with open(policy_file) as f:
             policy_text = f.read()
-        os.remove(policy_file)
+        # Don't delete - needed if proxy restarts
         proxy_logging.logger.info(f"Loaded policy from {policy_file} ({len(policy_text)} bytes)")
     else:
         proxy_logging.logger.info("No policy file, using empty policy")

--- a/src/setup/supervisor.sh
+++ b/src/setup/supervisor.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Minimal proxy supervisor with restart capability
+#
+# Restarts proxy once on unexpected termination.
+# On second crash, cleans up iptables and exits.
+
+set -e
+
+SCRIPT_DIR="$(dirname "$0")"
+REPO_ROOT="${EGRESS_FILTER_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+PIDFILE="/tmp/proxy.pid"
+
+RESTART_COUNT=0
+MAX_RESTARTS=1
+CLEAN_SHUTDOWN=0
+PROXY_PID=""
+
+log() {
+    echo "[supervisor] $1" >> /tmp/proxy-stdout.log
+}
+
+handle_sigterm() {
+    CLEAN_SHUTDOWN=1
+    log "Received SIGTERM, forwarding to proxy"
+    if [[ -n "$PROXY_PID" ]] && kill -0 "$PROXY_PID" 2>/dev/null; then
+        kill -TERM "$PROXY_PID" 2>/dev/null || true
+    fi
+}
+
+start_proxy() {
+    log "Starting proxy (attempt $((RESTART_COUNT + 1)))"
+
+    # Start proxy as child - inherits our cgroup
+    env PROXY_LOG_FILE=/tmp/proxy.log VERBOSE="${VERBOSE:-0}" PYTHONPATH="$REPO_ROOT/src" \
+        EGRESS_POLICY_FILE="${EGRESS_POLICY_FILE:-}" EGRESS_AUDIT_MODE="${EGRESS_AUDIT_MODE:-0}" \
+        GITHUB_ACTION_REPOSITORY="${GITHUB_ACTION_REPOSITORY:-}" \
+        GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-}" \
+        EGRESS_ALLOW_SUDO="${EGRESS_ALLOW_SUDO:-0}" \
+        "$REPO_ROOT"/.venv/bin/python -m proxy.main >> /tmp/proxy-stdout.log 2>&1 &
+    PROXY_PID=$!
+    echo "$PROXY_PID" > "$PIDFILE"
+    log "Proxy started with PID $PROXY_PID"
+
+    # Wait for port 8080
+    local counter=0
+    while ! ss -tln | grep -q ':8080 '; do
+        sleep 0.1
+        counter=$((counter + 1))
+        if ! kill -0 "$PROXY_PID" 2>/dev/null; then
+            log "Proxy died during startup"
+            return 1
+        fi
+        if [[ $counter -gt 100 ]]; then
+            log "Timeout waiting for port 8080"
+            kill -TERM "$PROXY_PID" 2>/dev/null || true
+            return 1
+        fi
+    done
+    log "Proxy ready"
+    return 0
+}
+
+main() {
+    trap 'handle_sigterm' SIGTERM SIGINT
+
+    while true; do
+        if ! start_proxy; then
+            if [[ $RESTART_COUNT -lt $MAX_RESTARTS ]]; then
+                RESTART_COUNT=$((RESTART_COUNT + 1))
+                log "Startup failed, retrying..."
+                continue
+            else
+                log "Startup failed twice, cleaning up"
+                "$SCRIPT_DIR/iptables.sh" cleanup 2>/dev/null || true
+                exit 1
+            fi
+        fi
+
+        # Wait for proxy to exit
+        wait "$PROXY_PID" 2>/dev/null || true
+
+        if [[ $CLEAN_SHUTDOWN -eq 1 ]]; then
+            log "Clean shutdown"
+            exit 0
+        fi
+
+        # Unexpected exit
+        if [[ $RESTART_COUNT -lt $MAX_RESTARTS ]]; then
+            RESTART_COUNT=$((RESTART_COUNT + 1))
+            log "Proxy crashed, restarting (attempt $RESTART_COUNT)"
+            continue
+        fi
+
+        log "Max restarts reached, cleaning up"
+        "$SCRIPT_DIR/iptables.sh" cleanup 2>/dev/null || true
+        exit 1
+    done
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Run supervisor inside the systemd scope so it keeps the cgroup alive when the proxy is killed
- This prevents iptables cgroup match rules from going stale
- Supervisor restarts proxy once on crash, then cleans up iptables
- Rely on systemd scope cleanup instead of manual wait loops

## Test plan
- [x] Workflow test: kill proxy with SIGKILL, verify restart and HTTPS works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)