### PR TITLE
fix: restore userns sysctl to original value

### DIFF
--- a/src/setup/proxy.sh
+++ b/src/setup/proxy.sh
@@ -43,6 +43,7 @@ install_deps() {
 PIDFILE="/tmp/proxy.pid"
 SUPERVISOR_PIDFILE="/tmp/supervisor.pid"
 SCOPE_NAME="egress-filter-proxy"
+USERNS_ORIG_FILE="/run/egress-filter-userns-orig"
 
 start_proxy() {
     cd "$REPO_ROOT"
@@ -63,6 +64,7 @@ start_proxy() {
     # Combined with disabling sudo (planned), this blocks ALL netns creation:
     # - Unprivileged: blocked by this sysctl
     # - Privileged: requires sudo which will be disabled
+    sysctl -n kernel.unprivileged_userns_clone > "$USERNS_ORIG_FILE"
     sysctl -w kernel.unprivileged_userns_clone=0 >/dev/null
 
     # Start supervisor in a systemd scope
@@ -133,8 +135,11 @@ stop_proxy() {
     # which breaks runner communication with GitHub (jobs appear stuck).
     "$SCRIPT_DIR"/iptables.sh cleanup 2>/dev/null || true
 
-    # Restore unprivileged user namespace creation (cleanup)
-    sysctl -w kernel.unprivileged_userns_clone=1 >/dev/null 2>&1 || true
+    # Restore unprivileged user namespace creation to original value
+    if [ -f "$USERNS_ORIG_FILE" ]; then
+        sysctl -w "kernel.unprivileged_userns_clone=$(cat "$USERNS_ORIG_FILE")" >/dev/null 2>&1 || true
+        rm -f "$USERNS_ORIG_FILE"
+    fi
 
     # Signal supervisor to shut down (it forwards SIGTERM to proxy)
     if [ -f "$SUPERVISOR_PIDFILE" ]; then


### PR DESCRIPTION
## Summary

Fixes #46

The action was setting `kernel.unprivileged_userns_clone=0` on start but always restoring it to `1` on stop, regardless of the original value. This could weaken host security if it was previously disabled.

## Changes

- Save original sysctl value to `/run/egress-filter-userns-orig` before modifying
- Restore the original value on stop instead of hardcoding `1`
- Clean up the state file after restore

## Test plan

- [ ] Verify on runner where userns is already disabled (value stays 0 after action)
- [ ] Verify on runner where userns is enabled (value returns to 1 after action)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)