### PR TITLE
fix: fail fast if nfqueue/scapy dependencies are missing

### DIFF
--- a/src/proxy/main.py
+++ b/src/proxy/main.py
@@ -59,12 +59,8 @@ async def run_mitmproxy(bpf: BPFState, enforcer: PolicyEnforcer):
 
 async def run_nfqueue(handler: NfqueueHandler):
     """Run nfqueue handler integrated with asyncio."""
-    if not handler.setup():
-        return
-
+    handler.setup()
     fd = handler.get_fd()
-    if fd is None:
-        return
 
     loop = asyncio.get_event_loop()
     loop.add_reader(fd, handler.process_pending)


### PR DESCRIPTION
## Summary

Fixes #45

Previously, if `netfilterqueue` or `scapy` were missing, the nfqueue handler would silently skip initialization while iptables NFQUEUE rules were still installed. This would cause UDP packets (including DNS) to be queued with no listener, resulting in dropped packets.

## Changes

- Remove try/except around `netfilterqueue` and `scapy` imports
- Remove `HAS_NFQUEUE` and `HAS_SCAPY` conditional checks
- Simplify `setup()`, `get_fd()`, `process_pending()`, and `cleanup()` methods

Now if dependencies are missing:
1. Import fails immediately
2. Proxy doesn't start
3. iptables rules are never installed
4. No orphaned NFQUEUE rules

## Test plan

- [ ] Verify proxy starts correctly with all deps installed
- [ ] Verify proxy fails to start if netfilterqueue is uninstalled

🤖 Generated with [Claude Code](https://claude.ai/claude-code)