### PR TITLE
fix: remove iptables table flush from cleanup

### DIFF
--- a/src/setup/iptables.sh
+++ b/src/setup/iptables.sh
@@ -96,15 +96,8 @@ setup() {
 }
 
 cleanup() {
-    # Delete rules (ignore errors - rules may not exist)
+    # Delete rules individually (ignore errors - rules may not exist)
     apply_rules -D true
-
-    # Flush tables as safety net (in case rules were partially added
-    # or script was interrupted)
-    iptables -t mangle -F 2>/dev/null || true
-    iptables -t nat -F 2>/dev/null || true
-    iptables -t filter -F 2>/dev/null || true
-    ip6tables -t filter -F 2>/dev/null || true
 }
 
 case "${1:-}" in


### PR DESCRIPTION
## Summary

Fixes #47

The cleanup was flushing entire `mangle`/`nat`/`filter` tables as a "safety net" after deleting individual rules. This could remove unrelated iptables rules on the host.

## Changes

Removed these lines from cleanup:
```bash
iptables -t mangle -F 2>/dev/null || true
iptables -t nat -F 2>/dev/null || true
iptables -t filter -F 2>/dev/null || true
ip6tables -t filter -F 2>/dev/null || true
```

`apply_rules -D` already deletes each rule individually using the same rule definitions as setup, so the flush is unnecessary.

## Test plan

- [x] Verify cleanup still removes egress-filter rules
- [ ] Verify unrelated iptables rules are preserved after cleanup

🤖 Generated with [Claude Code](https://claude.ai/claude-code)