### PR TITLE
security: protect policy file from modification after startup

### DIFF
--- a/src/setup/proxy.sh
+++ b/src/setup/proxy.sh
@@ -67,6 +67,13 @@ SCOPE_NAME="egress-filter-proxy"
 start_proxy() {
     cd "$REPO_ROOT"
 
+    # Protect policy file from modification by workflow code.
+    # File is created by pre.js (runner user) but proxy runs as root.
+    # Without this, attacker could modify policy and crash proxy to reload it.
+    if [ -n "$EGRESS_POLICY_FILE" ] && [ -f "$EGRESS_POLICY_FILE" ]; then
+        chown root:root "$EGRESS_POLICY_FILE"
+    fi
+
     # Cleanup iptables on failure to avoid breaking runner communication
     trap '"$SCRIPT_DIR"/iptables.sh cleanup' ERR
 


### PR DESCRIPTION
## Summary
The policy file is created by pre.js (runner user) but read by the proxy (root). Without protection, workflow code could:

1. Modify `/tmp/egress-policy.txt` to allow malicious domains
2. Crash the proxy (exploit bug, resource exhaustion, etc.)
3. Supervisor restarts proxy with attacker's policy

Fix: `chown root:root` the policy file at the start of proxy.sh, before the proxy reads it.

Found during investigation of #41.

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)