### PR TITLE
test: add handler tests for MitmproxyAddon and NfqueueHandler

### DIFF
--- a/tests/test_handler_mitmproxy.py
+++ b/tests/test_handler_mitmproxy.py
@@ -1,0 +1,668 @@
+"""Tests for MitmproxyAddon (proxy.handlers.mitmproxy)."""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from proxy.policy.enforcer import Decision, ProcessInfo, Verdict
+
+
+# ---------------------------------------------------------------------------
+# Mock helpers
+# ---------------------------------------------------------------------------
+
+class MockBPFState:
+    """Minimal BPFState mock with configurable PID lookup."""
+
+    def __init__(self, pid=1234):
+        self._pid = pid
+        self.dns_cache = {}
+
+    def lookup_pid(self, dst_ip, src_port, dst_port, protocol=6):
+        return self._pid
+
+
+def _make_decision(allowed, rule_idx=0):
+    """Create a real Decision object."""
+    if allowed:
+        return Decision(
+            verdict=Verdict.ALLOW,
+            reason=f"Matched rule {rule_idx}",
+            matched_rule=rule_idx,
+        )
+    return Decision(
+        verdict=Verdict.BLOCK,
+        reason="No matching rule",
+        matched_rule=None,
+    )
+
+
+# -- Flow factories (SimpleNamespace-based, matching dump tool output) --
+
+def make_tls_clienthello_data(sni="example.com", dst_ip="93.184.216.34",
+                               dst_port=443, src_port=54321):
+    """Create a tls.ClientHelloData-like object."""
+    data = SimpleNamespace(
+        context=SimpleNamespace(
+            client=SimpleNamespace(peername=("127.0.0.1", src_port)),
+            server=SimpleNamespace(address=(dst_ip, dst_port)),
+        ),
+        client_hello=SimpleNamespace(sni=sni),
+        ignore_connection=False,
+    )
+    return data
+
+
+def make_http_flow(url="http://example.com/path", method="GET",
+                   dst_ip="93.184.216.34", dst_port=80, src_port=54321):
+    """Create an http.HTTPFlow-like object."""
+    flow = SimpleNamespace(
+        client_conn=SimpleNamespace(peername=("127.0.0.1", src_port)),
+        server_conn=SimpleNamespace(address=(dst_ip, dst_port)),
+        request=SimpleNamespace(pretty_url=url, method=method),
+        response=None,
+    )
+    return flow
+
+
+def make_tcp_flow(dst_ip="93.184.216.34", dst_port=8080, src_port=54321):
+    """Create a tcp.TCPFlow-like object."""
+    flow = SimpleNamespace(
+        client_conn=SimpleNamespace(peername=("127.0.0.1", src_port)),
+        server_conn=SimpleNamespace(address=(dst_ip, dst_port)),
+    )
+    flow.kill = MagicMock()
+    return flow
+
+
+def make_dns_flow(query_name="example.com", txid=0x1234, src_port=54321,
+                  flow_id="test-flow-id"):
+    """Create a dns.DNSFlow-like object for dns_request."""
+    question = SimpleNamespace(name=query_name, type=1, class_=1)
+    flow = SimpleNamespace(
+        id=flow_id,
+        client_conn=SimpleNamespace(peername=("127.0.0.1", src_port)),
+        request=SimpleNamespace(
+            id=txid,
+            questions=[question],
+            op_code=0,
+            recursion_desired=True,
+        ),
+        response=None,
+    )
+    return flow
+
+
+def make_dns_flow_with_response(query_name="example.com", answers=None,
+                                flow_id="test-flow-id"):
+    """Create a dns.DNSFlow-like object for dns_response."""
+    question = SimpleNamespace(name=query_name, type=1, class_=1)
+    flow = SimpleNamespace(
+        id=flow_id,
+        request=SimpleNamespace(
+            id=0x1234,
+            questions=[question],
+        ),
+        response=SimpleNamespace(answers=answers or []),
+    )
+    return flow
+
+
+def make_dns_answer(ip="93.184.216.34", ttl=300, record_type=1):
+    """Create a DNS answer record."""
+    answer = SimpleNamespace(type=record_type, ttl=ttl)
+    if record_type == 1:  # A record
+        answer.ipv4_address = ip
+    elif record_type == 28:  # AAAA record
+        answer.ipv6_address = ip
+    return answer
+
+
+def make_tls_data(sni="example.com", dst_ip="93.184.216.34", dst_port=443,
+                  src_port=54321):
+    """Create a tls.TlsData-like object for tls_failed_client."""
+    data = SimpleNamespace(
+        context=SimpleNamespace(
+            client=SimpleNamespace(
+                peername=("127.0.0.1", src_port),
+                sni=sni,
+            ),
+            server=SimpleNamespace(address=(dst_ip, dst_port)),
+        ),
+    )
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+PROC_DICT = {"exe": "/usr/bin/curl", "cgroup": "/system.slice/runner.service"}
+
+
+@pytest.fixture
+def enforcer():
+    """Mock PolicyEnforcer."""
+    mock = MagicMock()
+    mock.check_https.return_value = _make_decision(True)
+    mock.check_http.return_value = _make_decision(True)
+    mock.check_tcp.return_value = _make_decision(True)
+    mock.check_dns.return_value = _make_decision(True)
+    mock.check_udp.return_value = _make_decision(True)
+    return mock
+
+
+@pytest.fixture
+def bpf():
+    return MockBPFState(pid=1234)
+
+
+@pytest.fixture
+def addon(bpf, enforcer):
+    """Create MitmproxyAddon with mocked dependencies."""
+    with patch("proxy.handlers.mitmproxy.get_proc_info", return_value=dict(PROC_DICT)), \
+         patch("proxy.handlers.mitmproxy.is_container_process", return_value=False), \
+         patch("proxy.handlers.mitmproxy.proxy_logging") as mock_logging:
+        mock_logging.log_connection = MagicMock()
+        mock_logging.logger = MagicMock()
+
+        from proxy.handlers.mitmproxy import MitmproxyAddon
+        a = MitmproxyAddon(bpf, enforcer)
+        # Stash references for assertions
+        a._mock_log_connection = mock_logging.log_connection
+        a._mock_logger = mock_logging.logger
+        yield a
+
+
+def _make_addon(bpf, enforcer, proc_dict=None, is_container=False):
+    """Helper: create addon with specific proc/container config.
+
+    Returns (addon, log_connection_mock, logger_mock).
+    """
+    if proc_dict is None:
+        proc_dict = dict(PROC_DICT)
+
+    with patch("proxy.handlers.mitmproxy.get_proc_info", return_value=proc_dict) as gpi, \
+         patch("proxy.handlers.mitmproxy.is_container_process", return_value=is_container) as icp, \
+         patch("proxy.handlers.mitmproxy.proxy_logging") as mock_logging:
+        mock_logging.log_connection = MagicMock()
+        mock_logging.logger = MagicMock()
+
+        from proxy.handlers.mitmproxy import MitmproxyAddon
+        a = MitmproxyAddon(bpf, enforcer)
+        yield a, mock_logging.log_connection, mock_logging.logger, gpi, icp
+
+
+# ---------------------------------------------------------------------------
+# Tests: tls_clienthello
+# ---------------------------------------------------------------------------
+
+class TestTlsClienthello:
+    """Tests for tls_clienthello hook."""
+
+    def test_container_sni_allowed_passthrough(self, bpf, enforcer):
+        """Container + SNI + allowed -> log, ignore_connection=True."""
+        enforcer.check_https.return_value = _make_decision(True)
+        gen = _make_addon(bpf, enforcer, is_container=True)
+        addon, log_conn, logger, _, _ = next(gen)
+
+        data = make_tls_clienthello_data(sni="example.com")
+        addon.tls_clienthello(data)
+
+        # Should passthrough (ignore MITM)
+        assert data.ignore_connection is True
+        # Should log the connection
+        log_conn.assert_called_once()
+        call_kw = log_conn.call_args.kwargs
+        assert call_kw["type"] == "https"
+        assert call_kw["host"] == "example.com"
+        assert call_kw["policy"] == "allow"
+        assert call_kw["pid"] == 1234
+
+    def test_container_sni_blocked(self, bpf, enforcer):
+        """Container + SNI + blocked -> log, client.error set."""
+        enforcer.check_https.return_value = _make_decision(False)
+        gen = _make_addon(bpf, enforcer, is_container=True)
+        addon, log_conn, _, _, _ = next(gen)
+
+        data = make_tls_clienthello_data(sni="evil.com")
+        addon.tls_clienthello(data)
+
+        # Should block
+        assert data.context.client.error == "Blocked by egress policy"
+        # Should log with deny
+        log_conn.assert_called_once()
+        assert log_conn.call_args.kwargs["policy"] == "deny"
+
+    def test_noncontainer_sni_allowed_mitm(self, bpf, enforcer):
+        """Non-container + SNI + allowed -> no log (defers to request()), can_mitm=True."""
+        enforcer.check_https.return_value = _make_decision(True)
+        gen = _make_addon(bpf, enforcer, is_container=False)
+        addon, log_conn, _, _, _ = next(gen)
+
+        data = make_tls_clienthello_data(sni="example.com")
+        addon.tls_clienthello(data)
+
+        # Should NOT passthrough (will MITM)
+        assert data.ignore_connection is False
+        # Should NOT log at this stage (deferred to request())
+        log_conn.assert_not_called()
+        # Enforcer called with can_mitm=True
+        enforcer.check_https.assert_called_once()
+        call_kw = enforcer.check_https.call_args.kwargs
+        assert call_kw["can_mitm"] is True
+
+    def test_noncontainer_sni_blocked(self, bpf, enforcer):
+        """Non-container + SNI + blocked -> log, client.error set."""
+        enforcer.check_https.return_value = _make_decision(False)
+        gen = _make_addon(bpf, enforcer, is_container=False)
+        addon, log_conn, _, _, _ = next(gen)
+
+        data = make_tls_clienthello_data(sni="evil.com")
+        addon.tls_clienthello(data)
+
+        assert data.context.client.error == "Blocked by egress policy"
+        log_conn.assert_called_once()
+        assert log_conn.call_args.kwargs["policy"] == "deny"
+
+    def test_noncontainer_no_sni_defers(self, bpf, enforcer):
+        """Non-container + no SNI -> no enforcement (defers to request())."""
+        gen = _make_addon(bpf, enforcer, is_container=False)
+        addon, log_conn, _, _, _ = next(gen)
+
+        data = make_tls_clienthello_data(sni=None)
+        addon.tls_clienthello(data)
+
+        # No enforcement at TLS stage
+        enforcer.check_https.assert_not_called()
+        log_conn.assert_not_called()
+        assert data.ignore_connection is False
+
+    def test_container_no_sni_enforces(self, bpf, enforcer):
+        """Container + no SNI -> enforces (can't decrypt), passthrough."""
+        enforcer.check_https.return_value = _make_decision(True)
+        gen = _make_addon(bpf, enforcer, is_container=True)
+        addon, log_conn, _, _, _ = next(gen)
+
+        data = make_tls_clienthello_data(sni=None)
+        addon.tls_clienthello(data)
+
+        # Should enforce since it's a container (can't MITM)
+        enforcer.check_https.assert_called_once()
+        assert data.ignore_connection is True
+
+    def test_pid_not_found(self, enforcer):
+        """PID not found -> still enforces with empty proc_dict."""
+        bpf = MockBPFState(pid=None)
+        gen = _make_addon(bpf, enforcer, proc_dict={}, is_container=False)
+        addon, log_conn, _, _, icp = next(gen)
+
+        data = make_tls_clienthello_data(sni="example.com")
+        addon.tls_clienthello(data)
+
+        # is_container_process should not be called when pid is None
+        icp.assert_not_called()
+        # sni is present, so should_enforce_now is True -> enforces
+        enforcer.check_https.assert_called_once()
+
+    def test_log_includes_proc_and_connection_info(self, bpf, enforcer):
+        """Log entry includes proc info fields, pid, and src_port."""
+        enforcer.check_https.return_value = _make_decision(True)
+        gen = _make_addon(bpf, enforcer, is_container=True,
+                          proc_dict={"exe": "/usr/bin/curl", "cgroup": "/test"})
+        addon, log_conn, _, _, _ = next(gen)
+
+        data = make_tls_clienthello_data(sni="example.com", src_port=12345)
+        addon.tls_clienthello(data)
+
+        kw = log_conn.call_args.kwargs
+        assert kw["exe"] == "/usr/bin/curl"
+        assert kw["cgroup"] == "/test"
+        assert kw["pid"] == 1234
+        assert kw["src_port"] == 12345
+        assert kw["dst_ip"] == "93.184.216.34"
+        assert kw["dst_port"] == 443
+
+
+# ---------------------------------------------------------------------------
+# Tests: request
+# ---------------------------------------------------------------------------
+
+class TestRequest:
+    """Tests for request hook (HTTP/HTTPS after MITM)."""
+
+    def test_http_allowed(self, bpf, enforcer):
+        """HTTP allowed -> log with type=http, no response set."""
+        enforcer.check_http.return_value = _make_decision(True)
+        gen = _make_addon(bpf, enforcer)
+        addon, log_conn, _, _, _ = next(gen)
+
+        flow = make_http_flow(url="http://example.com/path", method="GET")
+        addon.request(flow)
+
+        assert flow.response is None
+        log_conn.assert_called_once()
+        kw = log_conn.call_args.kwargs
+        assert kw["type"] == "http"
+        assert kw["url"] == "http://example.com/path"
+        assert kw["method"] == "GET"
+        assert kw["policy"] == "allow"
+
+    def test_http_blocked(self, bpf, enforcer):
+        """HTTP blocked -> log with policy=deny, 403 response."""
+        enforcer.check_http.return_value = _make_decision(False)
+        gen = _make_addon(bpf, enforcer)
+        addon, log_conn, _, _, _ = next(gen)
+
+        flow = make_http_flow(url="http://evil.com/", method="POST")
+        addon.request(flow)
+
+        assert flow.response is not None
+        assert flow.response.status_code == 403
+        log_conn.assert_called_once()
+        assert log_conn.call_args.kwargs["policy"] == "deny"
+
+    def test_https_mitmed(self, bpf, enforcer):
+        """HTTPS (MITMed) -> log with type=https."""
+        enforcer.check_http.return_value = _make_decision(True)
+        gen = _make_addon(bpf, enforcer)
+        addon, log_conn, _, _, _ = next(gen)
+
+        flow = make_http_flow(url="https://example.com/secure", method="GET",
+                              dst_port=443)
+        addon.request(flow)
+
+        kw = log_conn.call_args.kwargs
+        assert kw["type"] == "https"
+
+    def test_enforcer_called_with_correct_args(self, bpf, enforcer):
+        """Enforcer called with correct dst_ip, dst_port, url, method, ProcessInfo."""
+        enforcer.check_http.return_value = _make_decision(True)
+        gen = _make_addon(bpf, enforcer, proc_dict={"exe": "/usr/bin/wget"})
+        addon, _, _, _, _ = next(gen)
+
+        flow = make_http_flow(url="http://example.com/api", method="POST",
+                              dst_ip="10.0.0.1", dst_port=8080)
+        addon.request(flow)
+
+        enforcer.check_http.assert_called_once()
+        kw = enforcer.check_http.call_args.kwargs
+        assert kw["dst_ip"] == "10.0.0.1"
+        assert kw["dst_port"] == 8080
+        assert kw["url"] == "http://example.com/api"
+        assert kw["method"] == "POST"
+        assert isinstance(kw["proc"], ProcessInfo)
+        assert kw["proc"].exe == "/usr/bin/wget"
+
+    def test_http_blocked_only_logs_once(self, bpf, enforcer):
+        """Blocked HTTP request should log exactly once."""
+        enforcer.check_http.return_value = _make_decision(False)
+        gen = _make_addon(bpf, enforcer)
+        addon, log_conn, _, _, _ = next(gen)
+
+        flow = make_http_flow(url="http://evil.com/")
+        addon.request(flow)
+
+        assert log_conn.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: tcp_start
+# ---------------------------------------------------------------------------
+
+class TestTcpStart:
+    """Tests for tcp_start hook."""
+
+    def test_allowed(self, bpf, enforcer):
+        """Allowed TCP -> log, not killed."""
+        enforcer.check_tcp.return_value = _make_decision(True)
+        gen = _make_addon(bpf, enforcer)
+        addon, log_conn, _, _, _ = next(gen)
+
+        flow = make_tcp_flow(dst_ip="10.0.0.1", dst_port=8080)
+        addon.tcp_start(flow)
+
+        flow.kill.assert_not_called()
+        log_conn.assert_called_once()
+        kw = log_conn.call_args.kwargs
+        assert kw["type"] == "tcp"
+        assert kw["policy"] == "allow"
+
+    def test_blocked(self, bpf, enforcer):
+        """Blocked TCP -> log, flow.kill() called."""
+        enforcer.check_tcp.return_value = _make_decision(False)
+        gen = _make_addon(bpf, enforcer)
+        addon, log_conn, _, _, _ = next(gen)
+
+        flow = make_tcp_flow()
+        addon.tcp_start(flow)
+
+        flow.kill.assert_called_once()
+        log_conn.assert_called_once()
+        assert log_conn.call_args.kwargs["policy"] == "deny"
+
+
+# ---------------------------------------------------------------------------
+# Tests: dns_request
+# ---------------------------------------------------------------------------
+
+class TestDnsRequest:
+    """Tests for dns_request hook."""
+
+    def test_cache_hit_allowed(self, bpf, enforcer):
+        """Cache hit + allowed -> log, stash in _pending_dns."""
+        enforcer.check_dns.return_value = _make_decision(True)
+        gen = _make_addon(bpf, enforcer)
+        addon, log_conn, _, _, _ = next(gen)
+
+        # Populate dns_cache (as nfqueue would)
+        bpf.dns_cache[(54321, 0x1234)] = (1234, "8.8.8.8", 53)
+
+        flow = make_dns_flow(query_name="example.com", txid=0x1234,
+                             src_port=54321, flow_id="flow-1")
+        addon.dns_request(flow)
+
+        # Should log
+        log_conn.assert_called_once()
+        kw = log_conn.call_args.kwargs
+        assert kw["type"] == "dns"
+        assert kw["name"] == "example.com"
+        assert kw["policy"] == "allow"
+        assert kw["dst_ip"] == "8.8.8.8"
+        assert kw["dst_port"] == 53
+
+        # Should stash for dns_response
+        assert "flow-1" in addon._pending_dns
+
+        # Cache entry consumed
+        assert (54321, 0x1234) not in bpf.dns_cache
+
+    def test_cache_hit_blocked(self, bpf, enforcer):
+        """Cache hit + blocked -> log, REFUSED response, NOT stashed."""
+        enforcer.check_dns.return_value = _make_decision(False)
+        gen = _make_addon(bpf, enforcer)
+        addon, log_conn, _, _, _ = next(gen)
+
+        bpf.dns_cache[(54321, 0x1234)] = (1234, "8.8.8.8", 53)
+
+        flow = make_dns_flow(query_name="evil.com", txid=0x1234,
+                             src_port=54321, flow_id="flow-2")
+        addon.dns_request(flow)
+
+        # Should set REFUSED response
+        assert flow.response is not None
+        assert flow.response.response_code == 5
+
+        # Should log with deny
+        log_conn.assert_called_once()
+        assert log_conn.call_args.kwargs["policy"] == "deny"
+
+        # Should NOT stash
+        assert "flow-2" not in addon._pending_dns
+
+    def test_cache_miss(self, bpf, enforcer):
+        """Cache miss -> logger.error, no enforcement."""
+        gen = _make_addon(bpf, enforcer)
+        addon, log_conn, logger, _, _ = next(gen)
+
+        # No dns_cache entry
+        flow = make_dns_flow(query_name="unknown.com", txid=0xAAAA,
+                             src_port=55555)
+        addon.dns_request(flow)
+
+        # Should log error
+        logger.error.assert_called_once()
+        assert "DNS cache miss" in logger.error.call_args[0][0]
+
+        # Should NOT call enforcer or log connection
+        enforcer.check_dns.assert_not_called()
+        log_conn.assert_not_called()
+
+    def test_uses_original_4tuple(self, bpf, enforcer):
+        """Uses original 4-tuple from nfqueue cache (pre-NAT dst_ip/dst_port)."""
+        enforcer.check_dns.return_value = _make_decision(True)
+        gen = _make_addon(bpf, enforcer)
+        addon, log_conn, _, _, _ = next(gen)
+
+        # nfqueue cached original destination (before NAT redirect to 127.0.0.1:8053)
+        bpf.dns_cache[(54321, 0x1234)] = (1234, "168.63.129.16", 53)
+
+        flow = make_dns_flow(query_name="example.com", txid=0x1234,
+                             src_port=54321)
+        addon.dns_request(flow)
+
+        # Enforcer should get original dst_ip/dst_port, not NAT'd
+        kw = enforcer.check_dns.call_args.kwargs
+        assert kw["dst_ip"] == "168.63.129.16"
+        assert kw["dst_port"] == 53
+
+
+# ---------------------------------------------------------------------------
+# Tests: dns_response
+# ---------------------------------------------------------------------------
+
+class TestDnsResponse:
+    """Tests for dns_response hook."""
+
+    def test_a_record_records_ips(self, bpf, enforcer):
+        """A record answers -> record_dns_response called with IPs and min TTL."""
+        gen = _make_addon(bpf, enforcer)
+        addon, log_conn, _, _, _ = next(gen)
+
+        # Stash pending context (as dns_request would)
+        addon._pending_dns["flow-1"] = dict(
+            dst_ip="8.8.8.8", dst_port=53, name="example.com",
+            policy="allow", src_port=54321, pid=1234,
+        )
+
+        answers = [
+            make_dns_answer(ip="93.184.216.34", ttl=300),
+            make_dns_answer(ip="93.184.216.35", ttl=200),
+        ]
+        flow = make_dns_flow_with_response("example.com", answers, flow_id="flow-1")
+        addon.dns_response(flow)
+
+        # Should call record_dns_response
+        enforcer.record_dns_response.assert_called_once_with(
+            "example.com", ["93.184.216.34", "93.184.216.35"], 200
+        )
+
+        # Should log dns_response event
+        log_conn.assert_called_once()
+        kw = log_conn.call_args.kwargs
+        assert kw["type"] == "dns_response"
+        assert kw["answers"] == ["93.184.216.34", "93.184.216.35"]
+        assert kw["ttl"] == 200
+
+    def test_no_response_noop(self, bpf, enforcer):
+        """No response -> no-op."""
+        gen = _make_addon(bpf, enforcer)
+        addon, log_conn, _, _, _ = next(gen)
+
+        flow = SimpleNamespace(
+            id="flow-1",
+            request=SimpleNamespace(questions=[SimpleNamespace(name="example.com")]),
+            response=None,
+        )
+        addon.dns_response(flow)
+
+        enforcer.record_dns_response.assert_not_called()
+        log_conn.assert_not_called()
+
+    def test_no_pending_context_still_records(self, bpf, enforcer):
+        """No pending context -> still records IPs, but no log event."""
+        gen = _make_addon(bpf, enforcer)
+        addon, log_conn, _, _, _ = next(gen)
+
+        answers = [make_dns_answer(ip="1.2.3.4", ttl=60)]
+        flow = make_dns_flow_with_response("test.com", answers, flow_id="no-pending")
+        addon.dns_response(flow)
+
+        # IPs still recorded
+        enforcer.record_dns_response.assert_called_once()
+        # But no connection log (no pending context)
+        log_conn.assert_not_called()
+
+    def test_min_ttl_used(self, bpf, enforcer):
+        """Multiple TTLs -> minimum is used."""
+        gen = _make_addon(bpf, enforcer)
+        addon, log_conn, _, _, _ = next(gen)
+
+        addon._pending_dns["flow-1"] = dict(
+            dst_ip="8.8.8.8", dst_port=53, name="multi.com",
+            policy="allow", src_port=54321, pid=1234,
+        )
+
+        answers = [
+            make_dns_answer(ip="1.1.1.1", ttl=500),
+            make_dns_answer(ip="2.2.2.2", ttl=100),
+            make_dns_answer(ip="3.3.3.3", ttl=300),
+        ]
+        flow = make_dns_flow_with_response("multi.com", answers, flow_id="flow-1")
+        addon.dns_response(flow)
+
+        # Should use minimum TTL
+        enforcer.record_dns_response.assert_called_once_with(
+            "multi.com", ["1.1.1.1", "2.2.2.2", "3.3.3.3"], 100
+        )
+
+    def test_no_answers_no_record(self, bpf, enforcer):
+        """Empty answers -> no record_dns_response call."""
+        gen = _make_addon(bpf, enforcer)
+        addon, log_conn, _, _, _ = next(gen)
+
+        flow = make_dns_flow_with_response("empty.com", answers=[], flow_id="flow-1")
+        addon.dns_response(flow)
+
+        enforcer.record_dns_response.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: tls_failed_client
+# ---------------------------------------------------------------------------
+
+class TestTlsFailedClient:
+    """Tests for tls_failed_client hook."""
+
+    def test_logs_tls_rejection(self, bpf, enforcer):
+        """Logs with error=tls_client_rejected_ca."""
+        gen = _make_addon(bpf, enforcer)
+        addon, log_conn, _, _, _ = next(gen)
+
+        data = make_tls_data(sni="strict.com", dst_ip="10.0.0.1", dst_port=443,
+                             src_port=12345)
+        addon.tls_failed_client(data)
+
+        log_conn.assert_called_once()
+        kw = log_conn.call_args.kwargs
+        assert kw["type"] == "https"
+        assert kw["host"] == "strict.com"
+        assert kw["error"] == "tls_client_rejected_ca"
+        assert kw["dst_ip"] == "10.0.0.1"
+        assert kw["pid"] == 1234
+        assert kw["src_port"] == 12345

--- a/tests/test_handler_nfqueue.py
+++ b/tests/test_handler_nfqueue.py
@@ -1,0 +1,256 @@
+"""Tests for NfqueueHandler (proxy.handlers.nfqueue)."""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from proxy.policy.enforcer import Decision, ProcessInfo, Verdict
+
+
+# ---------------------------------------------------------------------------
+# Mock helpers
+# ---------------------------------------------------------------------------
+
+class MockBPFState:
+    """Minimal BPFState mock with configurable PID lookup."""
+
+    def __init__(self, pid=1234):
+        self._pid = pid
+        self.dns_cache = {}
+
+    def lookup_pid(self, dst_ip, src_port, dst_port, protocol=6):
+        return self._pid
+
+
+def _make_decision(allowed, rule_idx=0):
+    """Create a real Decision object."""
+    if allowed:
+        return Decision(
+            verdict=Verdict.ALLOW,
+            reason=f"Matched rule {rule_idx}",
+            matched_rule=rule_idx,
+        )
+    return Decision(
+        verdict=Verdict.BLOCK,
+        reason="No matching rule",
+        matched_rule=None,
+    )
+
+
+class MockNfPacket:
+    """Mock nfqueue packet tracking set_mark, repeat, and drop calls."""
+
+    def __init__(self, payload: bytes):
+        self._payload = payload
+        self.marks = []
+        self.repeated = False
+        self.dropped = False
+
+    def get_payload(self) -> bytes:
+        return self._payload
+
+    def set_mark(self, mark: int) -> None:
+        self.marks.append(mark)
+
+    def repeat(self) -> None:
+        self.repeated = True
+
+    def drop(self) -> None:
+        self.dropped = True
+
+
+def _make_dns_packet(src_ip="10.0.0.1", dst_ip="8.8.8.8",
+                     sport=54321, dport=53, txid=0x1234) -> bytes:
+    """Build a raw DNS query packet using scapy."""
+    from scapy.layers.dns import DNS, DNSQR
+    from scapy.layers.inet import IP, UDP
+
+    pkt = (
+        IP(src=src_ip, dst=dst_ip)
+        / UDP(sport=sport, dport=dport)
+        / DNS(id=txid, qr=0, qd=DNSQR(qname="example.com"))
+    )
+    return bytes(pkt)
+
+
+def _make_udp_packet(src_ip="10.0.0.1", dst_ip="192.168.1.100",
+                     sport=54321, dport=9999, payload=b"hello") -> bytes:
+    """Build a raw non-DNS UDP packet using scapy."""
+    from scapy.layers.inet import IP, UDP
+
+    pkt = IP(src=src_ip, dst=dst_ip) / UDP(sport=sport, dport=dport) / payload
+    return bytes(pkt)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+PROC_DICT = {"exe": "/usr/bin/curl", "cgroup": "/system.slice/runner.service"}
+
+
+@pytest.fixture
+def enforcer():
+    """Mock PolicyEnforcer."""
+    mock = MagicMock()
+    mock.check_udp.return_value = _make_decision(True)
+    return mock
+
+
+@pytest.fixture
+def bpf():
+    return MockBPFState(pid=1234)
+
+
+def _make_handler(bpf, enforcer, proc_dict=None):
+    """Create NfqueueHandler with mocked dependencies.
+
+    Returns (handler, log_connection_mock, logger_mock).
+    """
+    if proc_dict is None:
+        proc_dict = dict(PROC_DICT)
+
+    with patch("proxy.handlers.nfqueue.get_proc_info", return_value=proc_dict), \
+         patch("proxy.handlers.nfqueue.proxy_logging") as mock_logging:
+        mock_logging.log_connection = MagicMock()
+        mock_logging.logger = MagicMock()
+
+        from proxy.handlers.nfqueue import NfqueueHandler
+        handler = NfqueueHandler(bpf, enforcer)
+        yield handler, mock_logging.log_connection, mock_logging.logger
+
+
+# ---------------------------------------------------------------------------
+# Tests: handle_packet
+# ---------------------------------------------------------------------------
+
+class TestHandlePacket:
+    """Tests for NfqueueHandler.handle_packet."""
+
+    def test_dns_packet_redirected(self, bpf, enforcer):
+        """DNS packet -> mark=2 (MARK_DNS_REDIRECT), repeat(), dns_cache populated."""
+        gen = _make_handler(bpf, enforcer)
+        handler, log_conn, _ = next(gen)
+
+        raw = _make_dns_packet(sport=54321, dport=53, txid=0xABCD)
+        pkt = MockNfPacket(raw)
+        handler.handle_packet(pkt)
+
+        # Mark for DNS redirect
+        assert pkt.marks == [2]  # MARK_DNS_REDIRECT
+        assert pkt.repeated is True
+        assert pkt.dropped is False
+
+        # dns_cache populated with (pid, dst_ip, dst_port)
+        cache_key = (54321, 0xABCD)
+        assert cache_key in bpf.dns_cache
+        pid, dst_ip, dst_port = bpf.dns_cache[cache_key]
+        assert pid == 1234
+        assert dst_ip == "8.8.8.8"
+        assert dst_port == 53
+
+        # DNS packets are NOT logged here (logged by mitmproxy's dns_request)
+        log_conn.assert_not_called()
+
+    def test_non_dns_udp_allowed(self, bpf, enforcer):
+        """Non-DNS UDP allowed -> mark=4 (MARK_FASTPATH), repeat()."""
+        enforcer.check_udp.return_value = _make_decision(True)
+        gen = _make_handler(bpf, enforcer)
+        handler, log_conn, _ = next(gen)
+
+        raw = _make_udp_packet(dst_ip="192.168.1.100", dport=9999)
+        pkt = MockNfPacket(raw)
+        handler.handle_packet(pkt)
+
+        assert pkt.marks == [4]  # MARK_FASTPATH
+        assert pkt.repeated is True
+        assert pkt.dropped is False
+
+        # Should log
+        log_conn.assert_called_once()
+        kw = log_conn.call_args.kwargs
+        assert kw["type"] == "udp"
+        assert kw["dst_ip"] == "192.168.1.100"
+        assert kw["dst_port"] == 9999
+        assert kw["policy"] == "allow"
+        assert kw["pid"] == 1234
+
+    def test_non_dns_udp_blocked(self, bpf, enforcer):
+        """Non-DNS UDP blocked -> drop(), no repeat()."""
+        enforcer.check_udp.return_value = _make_decision(False)
+        gen = _make_handler(bpf, enforcer)
+        handler, log_conn, _ = next(gen)
+
+        raw = _make_udp_packet()
+        pkt = MockNfPacket(raw)
+        handler.handle_packet(pkt)
+
+        assert pkt.dropped is True
+        assert pkt.repeated is False
+        # No marks set on drop
+        assert pkt.marks == []
+
+        # Should log with deny
+        log_conn.assert_called_once()
+        assert log_conn.call_args.kwargs["policy"] == "deny"
+
+    def test_packet_count_incremented(self, bpf, enforcer):
+        """Packet count incremented per packet."""
+        gen = _make_handler(bpf, enforcer)
+        handler, _, _ = next(gen)
+
+        assert handler.packet_count == 0
+
+        raw = _make_udp_packet()
+        handler.handle_packet(MockNfPacket(raw))
+        assert handler.packet_count == 1
+
+        handler.handle_packet(MockNfPacket(raw))
+        assert handler.packet_count == 2
+
+    def test_dns_no_enforcer_call(self, bpf, enforcer):
+        """Enforcer NOT called for DNS (policy checked in mitmproxy, not nfqueue)."""
+        gen = _make_handler(bpf, enforcer)
+        handler, _, _ = next(gen)
+
+        raw = _make_dns_packet()
+        handler.handle_packet(MockNfPacket(raw))
+
+        enforcer.check_udp.assert_not_called()
+
+    def test_non_dns_log_includes_correct_fields(self, bpf, enforcer):
+        """Log entry for non-DNS includes type=udp and correct fields."""
+        enforcer.check_udp.return_value = _make_decision(True)
+        gen = _make_handler(bpf, enforcer, proc_dict={"exe": "/usr/bin/app"})
+        handler, log_conn, _ = next(gen)
+
+        raw = _make_udp_packet(src_ip="10.0.0.5", dst_ip="172.16.0.1",
+                               sport=33333, dport=5000)
+        handler.handle_packet(MockNfPacket(raw))
+
+        kw = log_conn.call_args.kwargs
+        assert kw["type"] == "udp"
+        assert kw["dst_ip"] == "172.16.0.1"
+        assert kw["dst_port"] == 5000
+        assert kw["src_port"] == 33333
+        assert kw["pid"] == 1234
+        assert kw["exe"] == "/usr/bin/app"
+
+    def test_enforcer_receives_process_info(self, bpf, enforcer):
+        """Enforcer called with ProcessInfo from proc_dict."""
+        enforcer.check_udp.return_value = _make_decision(True)
+        gen = _make_handler(bpf, enforcer, proc_dict={"exe": "/usr/bin/app", "cgroup": "/test"})
+        handler, _, _ = next(gen)
+
+        raw = _make_udp_packet()
+        handler.handle_packet(MockNfPacket(raw))
+
+        enforcer.check_udp.assert_called_once()
+        kw = enforcer.check_udp.call_args.kwargs
+        assert isinstance(kw["proc"], ProcessInfo)
+        assert kw["proc"].exe == "/usr/bin/app"
+        assert kw["proc"].cgroup == "/test"

--- a/tools/dump_mitmproxy_flows.py
+++ b/tools/dump_mitmproxy_flows.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Dump mitmproxy flow objects to understand their structure for test mocks.
+
+Runs mitmproxy as an explicit proxy (no root/iptables needed) and dumps the
+attributes our MitmproxyAddon accesses for each hook.
+
+Usage:
+    # Start the dumper (HTTP proxy on :8080, DNS on :8053):
+    uv run --extra proxy python tools/dump_mitmproxy_flows.py
+
+    # In another terminal, generate flows:
+    curl -x http://localhost:8080 http://example.com           # HTTP request
+    curl -x http://localhost:8080 -k https://example.com       # HTTPS (MITM)
+    dig @127.0.0.1 -p 8053 example.com                        # DNS
+
+Output is JSON, one object per hook invocation, separated by ---.
+"""
+
+import asyncio
+import json
+import sys
+
+from mitmproxy import dns, http, tcp, tls
+from mitmproxy.options import Options
+from mitmproxy.tools.dump import DumpMaster
+
+
+def _dump(hook_name: str, attrs: dict, types: dict) -> None:
+    """Print a structured dump."""
+    print(json.dumps({"hook": hook_name, "attrs": attrs, "types": types},
+                     indent=2, default=str))
+    print("---")
+    sys.stdout.flush()
+
+
+def _type_path(obj, *attrs):
+    """Walk an attribute path and return the type at each step."""
+    result = {}
+    current = obj
+    path = ""
+    for attr in attrs:
+        path = f"{path}.{attr}" if path else attr
+        try:
+            current = getattr(current, attr)
+            result[path] = type(current).__qualname__
+        except Exception as e:
+            result[path] = f"<error: {e}>"
+            break
+    return result
+
+
+class FlowDumper:
+    """Mitmproxy addon that dumps the flow attributes our addon accesses."""
+
+    def tls_clienthello(self, data: tls.ClientHelloData) -> None:
+        attrs = {
+            "context.client.peername": data.context.client.peername,
+            "context.server.address": data.context.server.address,
+            "client_hello.sni": data.client_hello.sni,
+        }
+        types = {
+            "data": type(data).__qualname__,
+            **_type_path(data, "context"),
+            **_type_path(data, "context", "client"),
+            **_type_path(data, "context", "server"),
+            **_type_path(data, "client_hello"),
+            # Settable attrs our addon uses:
+            "data.ignore_connection": type(data.ignore_connection).__qualname__,
+        }
+        _dump("tls_clienthello", attrs, types)
+
+    def request(self, flow: http.HTTPFlow) -> None:
+        attrs = {
+            "client_conn.peername": flow.client_conn.peername,
+            "server_conn.address": flow.server_conn.address,
+            "request.pretty_url": flow.request.pretty_url,
+            "request.method": flow.request.method,
+            "request.scheme": flow.request.scheme,
+            "request.host": flow.request.host,
+        }
+        types = {
+            "flow": type(flow).__qualname__,
+            **_type_path(flow, "client_conn"),
+            **_type_path(flow, "server_conn"),
+            **_type_path(flow, "request"),
+        }
+        _dump("request", attrs, types)
+
+    def tcp_start(self, flow: tcp.TCPFlow) -> None:
+        attrs = {
+            "client_conn.peername": flow.client_conn.peername,
+            "server_conn.address": flow.server_conn.address,
+        }
+        types = {
+            "flow": type(flow).__qualname__,
+            **_type_path(flow, "client_conn"),
+            **_type_path(flow, "server_conn"),
+        }
+        _dump("tcp_start", attrs, types)
+
+    def dns_request(self, flow: dns.DNSFlow) -> None:
+        questions = []
+        for q in flow.request.questions:
+            questions.append({
+                "name": q.name, "type": q.type, "class_": q.class_,
+            })
+        attrs = {
+            "client_conn.peername": flow.client_conn.peername,
+            "flow.id": flow.id,
+            "request.id": flow.request.id,
+            "request.questions": questions,
+        }
+        types = {
+            "flow": type(flow).__qualname__,
+            **_type_path(flow, "request"),
+            "question": type(flow.request.questions[0]).__qualname__ if flow.request.questions else None,
+        }
+        _dump("dns_request", attrs, types)
+
+    def dns_response(self, flow: dns.DNSFlow) -> None:
+        if not flow.response:
+            return
+        answers = []
+        for a in flow.response.answers:
+            entry = {"name": a.name, "type": a.type}
+            if hasattr(a, "ttl"):
+                entry["ttl"] = a.ttl
+            if a.type == 1:
+                entry["ipv4_address"] = str(a.ipv4_address)
+                entry["data_hex"] = a.data.hex()
+            elif a.type == 28:
+                entry["ipv6_address"] = str(a.ipv6_address)
+                entry["data_hex"] = a.data.hex()
+            if a.type == 5:  # CNAME
+                entry["data_hex"] = a.data.hex()
+            answers.append(entry)
+        attrs = {
+            "flow.id": flow.id,
+            "request.questions[0].name": (
+                flow.request.questions[0].name if flow.request.questions else None
+            ),
+            "response.answers": answers,
+        }
+        types = {
+            "response": type(flow.response).__qualname__,
+            "answer": type(flow.response.answers[0]).__qualname__ if flow.response.answers else None,
+        }
+        _dump("dns_response", attrs, types)
+
+    def tls_failed_client(self, data: tls.TlsData) -> None:
+        attrs = {
+            "context.client.peername": data.context.client.peername,
+            "context.server.address": data.context.server.address,
+            "context.client.sni": data.context.client.sni,
+        }
+        types = {
+            "data": type(data).__qualname__,
+        }
+        _dump("tls_failed_client", attrs, types)
+
+
+async def main():
+    opts = Options(
+        mode=["regular", "dns@8053"],
+        listen_port=8080,
+        showhost=True,
+    )
+    master = DumpMaster(opts)
+    master.addons.add(FlowDumper())
+
+    print("Flow dumper running:", file=sys.stderr)
+    print("  HTTP/HTTPS proxy:  localhost:8080", file=sys.stderr)
+    print("  DNS:               localhost:8053", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("Generate flows with:", file=sys.stderr)
+    print("  curl -x http://localhost:8080 http://example.com", file=sys.stderr)
+    print("  curl -x http://localhost:8080 -k https://example.com", file=sys.stderr)
+    print("  dig @127.0.0.1 -p 8053 example.com", file=sys.stderr)
+    print("", file=sys.stderr)
+
+    await master.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

- Add unit tests for all `MitmproxyAddon` hooks: `tls_clienthello`, `request`, `tcp_start`, `dns_request`, `dns_response`, `tls_failed_client`
- Add unit tests for `NfqueueHandler` packet handling: DNS redirect marking, non-DNS allow/block
- Uses `SimpleNamespace` flow factories and patched dependencies — no mitmproxy runtime needed

## Test plan

- [x] `uv run --extra proxy --with pytest python -m pytest tests/test_handler_mitmproxy.py tests/test_handler_nfqueue.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)