### PR TITLE
Split test_policy.py into per-module test files

### DIFF
--- a/tests/test_policy_enforcer.py
+++ b/tests/test_policy_enforcer.py
@@ -1,0 +1,178 @@
+"""Tests for policy enforcement: end-to-end enforcer scenarios.
+
+Uses YAML test fixtures from tests/fixtures/.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from proxy.policy import (
+    DNSIPCache,
+    PolicyEnforcer,
+    PolicyMatcher,
+    ProcessInfo,
+)
+
+# =============================================================================
+# Load test fixtures
+# =============================================================================
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def load_fixture(name: str) -> dict:
+    """Load a YAML test fixture."""
+    path = FIXTURES_DIR / f"{name}.yaml"
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+# =============================================================================
+# Policy Enforcer End-to-End Tests
+# =============================================================================
+
+ENFORCER_FIXTURE = load_fixture("policy_enforcer")
+
+
+def generate_enforcer_test_cases():
+    """Generate individual test cases from the enforcer fixture.
+
+    Each test scenario may have multiple checks. We generate a test case
+    for each check, but process the entire scenario (including dns_response
+    events) to maintain state.
+    """
+    cases = []
+    for test in ENFORCER_FIXTURE["tests"]:
+        test_name = test["name"]
+        policy = test["policy"]
+        dns_cache = test.get("dns_cache", [])
+        audit_mode = test.get("audit_mode", False)
+        checks = test["checks"]
+
+        # Group checks into scenario
+        cases.append(
+            {
+                "name": test_name,
+                "policy": policy,
+                "dns_cache": dns_cache,
+                "audit_mode": audit_mode,
+                "checks": checks,
+            }
+        )
+    return cases
+
+
+ENFORCER_TEST_CASES = generate_enforcer_test_cases()
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    ENFORCER_TEST_CASES,
+    ids=[c["name"] for c in ENFORCER_TEST_CASES],
+)
+def test_policy_enforcer(scenario):
+    """Test enforcer scenarios from YAML fixtures."""
+    # Set up enforcer
+    matcher = PolicyMatcher(scenario["policy"])
+    dns_cache = DNSIPCache()
+
+    # Pre-populate DNS cache
+    for entry in scenario["dns_cache"]:
+        dns_cache.add_many(
+            entry["ips"],
+            entry["hostname"],
+            entry.get("ttl", 300),
+        )
+
+    enforcer = PolicyEnforcer(matcher, dns_cache, audit_mode=scenario["audit_mode"])
+
+    # Process each check in sequence
+    for i, check in enumerate(scenario["checks"]):
+        check_type = check["type"]
+
+        # dns_response is not a check - it updates the cache
+        if check_type == "dns_response":
+            enforcer.record_dns_response(
+                query_name=check["query_name"],
+                ips=check["ips"],
+                ttl=check.get("ttl", 300),
+            )
+            continue
+
+        # Build process info if provided
+        proc = None
+        if "proc" in check:
+            proc = ProcessInfo(
+                exe=check["proc"].get("exe"),
+                cmdline=check["proc"].get("cmdline"),
+                cgroup=check["proc"].get("cgroup"),
+                step=check["proc"].get("step"),
+            )
+
+        # Run the appropriate check
+        if check_type == "https":
+            decision = enforcer.check_https(
+                dst_ip=check["dst_ip"],
+                dst_port=check["dst_port"],
+                sni=check.get("sni"),
+                proc=proc,
+                can_mitm=check.get("can_mitm", False),
+            )
+        elif check_type == "http":
+            decision = enforcer.check_http(
+                dst_ip=check["dst_ip"],
+                dst_port=check["dst_port"],
+                url=check["url"],
+                method=check["method"],
+                proc=proc,
+            )
+        elif check_type == "tcp":
+            decision = enforcer.check_tcp(
+                dst_ip=check["dst_ip"],
+                dst_port=check["dst_port"],
+                proc=proc,
+            )
+        elif check_type == "dns":
+            decision = enforcer.check_dns(
+                dst_ip=check["dst_ip"],
+                dst_port=check["dst_port"],
+                query_name=check["query_name"],
+                proc=proc,
+            )
+        elif check_type == "udp":
+            decision = enforcer.check_udp(
+                dst_ip=check["dst_ip"],
+                dst_port=check["dst_port"],
+                proc=proc,
+            )
+        else:
+            pytest.fail(f"Unknown check type: {check_type}")
+
+        # Verify verdict
+        expected_verdict = check["verdict"]
+        actual_verdict = "allow" if decision.allowed else "block"
+
+        assert actual_verdict == expected_verdict, (
+            f"Scenario '{scenario['name']}', check {i} ({check_type}):\n"
+            f"Check: {check}\n"
+            f"Expected: {expected_verdict}, Got: {actual_verdict}\n"
+            f"Reason: {decision.reason}"
+        )
+
+        # Check passthrough flag if specified in fixture
+        if "passthrough" in check:
+            expected_passthrough = check["passthrough"]
+            assert decision.passthrough == expected_passthrough, (
+                f"Scenario '{scenario['name']}', check {i} ({check_type}):\n"
+                f"Check: {check}\n"
+                f"Expected passthrough: {expected_passthrough}, Got: {decision.passthrough}"
+            )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_policy_matcher.py
+++ b/tests/test_policy_matcher.py
@@ -1,0 +1,100 @@
+"""Tests for policy matching: verdict computation and attribute matching.
+
+Uses YAML test fixtures from tests/fixtures/.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from proxy.policy import PolicyMatcher
+
+# =============================================================================
+# Load test fixtures
+# =============================================================================
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def load_fixture(name: str) -> dict:
+    """Load a YAML test fixture."""
+    path = FIXTURES_DIR / f"{name}.yaml"
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+# =============================================================================
+# Policy Match Tests
+# =============================================================================
+
+MATCH_FIXTURE = load_fixture("policy_match")
+
+
+def generate_match_test_cases():
+    """Generate individual test cases from the match fixture."""
+    cases = []
+    for test in MATCH_FIXTURE["tests"]:
+        policy = test["policy"]
+        for i, conn in enumerate(test["connections"]):
+            case_id = f"{test['name']} - connection {i}"
+            cases.append((case_id, policy, conn["event"], conn["verdict"]))
+    return cases
+
+
+MATCH_TEST_CASES = generate_match_test_cases()
+
+
+@pytest.mark.parametrize(
+    "case_id,policy,event,expected_verdict",
+    MATCH_TEST_CASES,
+    ids=[c[0] for c in MATCH_TEST_CASES],
+)
+def test_policy_match(case_id, policy, event, expected_verdict):
+    """Test connection matching against policy."""
+    matcher = PolicyMatcher(policy)
+    actual_verdict = matcher.verdict(event)
+
+    assert actual_verdict == expected_verdict, (
+        f"Verdict mismatch for '{case_id}':\n"
+        f"Policy:\n{policy}\n"
+        f"Event: {event}\n"
+        f"Expected: {expected_verdict}, Got: {actual_verdict}"
+    )
+
+
+# =============================================================================
+# Attribute Matching
+# =============================================================================
+
+
+class TestUnknownAttributes:
+    """Defense-in-depth: match_attrs rejects unknown attribute keys."""
+
+    def test_unknown_key_returns_false(self):
+        from proxy.policy.matcher import match_attrs, ConnectionEvent
+        from proxy.policy.types import Rule
+
+        rule = Rule(
+            type="host",
+            target="github.com",
+            port=[443],
+            protocol="tcp",
+            methods=None,
+            url_base=None,
+            attrs={"typo": "foo"},
+        )
+        event = ConnectionEvent(
+            type="https",
+            dst_ip="140.82.121.4",
+            dst_port=443,
+            host="github.com",
+        )
+        assert not match_attrs(rule, event)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_policy_parser.py
+++ b/tests/test_policy_parser.py
@@ -1,8 +1,9 @@
-"""Test suite runner for policy parsing and matching.
+"""Tests for policy parsing: flattening, DefaultContext, placeholders, rule_to_dict.
 
-Uses language-agnostic YAML test fixtures from tests/fixtures/.
+Uses YAML test fixtures from tests/fixtures/.
 """
 
+import json
 import sys
 from pathlib import Path
 
@@ -13,10 +14,6 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from proxy.policy import (
     DefaultContext,
-    DNSIPCache,
-    PolicyEnforcer,
-    PolicyMatcher,
-    ProcessInfo,
     parse_policy,
     rule_to_dict,
 )
@@ -175,187 +172,6 @@ def test_default_context(test_case):
 
 
 # =============================================================================
-# Policy Match Tests
-# =============================================================================
-
-MATCH_FIXTURE = load_fixture("policy_match")
-
-
-def generate_match_test_cases():
-    """Generate individual test cases from the match fixture."""
-    cases = []
-    for test in MATCH_FIXTURE["tests"]:
-        policy = test["policy"]
-        for i, conn in enumerate(test["connections"]):
-            case_id = f"{test['name']} - connection {i}"
-            cases.append((case_id, policy, conn["event"], conn["verdict"]))
-    return cases
-
-
-MATCH_TEST_CASES = generate_match_test_cases()
-
-
-@pytest.mark.parametrize(
-    "case_id,policy,event,expected_verdict",
-    MATCH_TEST_CASES,
-    ids=[c[0] for c in MATCH_TEST_CASES],
-)
-def test_policy_match(case_id, policy, event, expected_verdict):
-    """Test connection matching against policy."""
-    matcher = PolicyMatcher(policy)
-    actual_verdict = matcher.verdict(event)
-
-    assert actual_verdict == expected_verdict, (
-        f"Verdict mismatch for '{case_id}':\n"
-        f"Policy:\n{policy}\n"
-        f"Event: {event}\n"
-        f"Expected: {expected_verdict}, Got: {actual_verdict}"
-    )
-
-
-# =============================================================================
-# Policy Enforcer End-to-End Tests
-# =============================================================================
-
-ENFORCER_FIXTURE = load_fixture("policy_enforcer")
-
-
-def generate_enforcer_test_cases():
-    """Generate individual test cases from the enforcer fixture.
-
-    Each test scenario may have multiple checks. We generate a test case
-    for each check, but process the entire scenario (including dns_response
-    events) to maintain state.
-    """
-    cases = []
-    for test in ENFORCER_FIXTURE["tests"]:
-        test_name = test["name"]
-        policy = test["policy"]
-        dns_cache = test.get("dns_cache", [])
-        audit_mode = test.get("audit_mode", False)
-        checks = test["checks"]
-
-        # Group checks into scenario
-        cases.append(
-            {
-                "name": test_name,
-                "policy": policy,
-                "dns_cache": dns_cache,
-                "audit_mode": audit_mode,
-                "checks": checks,
-            }
-        )
-    return cases
-
-
-ENFORCER_TEST_CASES = generate_enforcer_test_cases()
-
-
-@pytest.mark.parametrize(
-    "scenario",
-    ENFORCER_TEST_CASES,
-    ids=[c["name"] for c in ENFORCER_TEST_CASES],
-)
-def test_policy_enforcer(scenario):
-    """Test enforcer scenarios from YAML fixtures."""
-    # Set up enforcer
-    matcher = PolicyMatcher(scenario["policy"])
-    dns_cache = DNSIPCache()
-
-    # Pre-populate DNS cache
-    for entry in scenario["dns_cache"]:
-        dns_cache.add_many(
-            entry["ips"],
-            entry["hostname"],
-            entry.get("ttl", 300),
-        )
-
-    enforcer = PolicyEnforcer(matcher, dns_cache, audit_mode=scenario["audit_mode"])
-
-    # Process each check in sequence
-    for i, check in enumerate(scenario["checks"]):
-        check_type = check["type"]
-
-        # dns_response is not a check - it updates the cache
-        if check_type == "dns_response":
-            enforcer.record_dns_response(
-                query_name=check["query_name"],
-                ips=check["ips"],
-                ttl=check.get("ttl", 300),
-            )
-            continue
-
-        # Build process info if provided
-        proc = None
-        if "proc" in check:
-            proc = ProcessInfo(
-                exe=check["proc"].get("exe"),
-                cmdline=check["proc"].get("cmdline"),
-                cgroup=check["proc"].get("cgroup"),
-                step=check["proc"].get("step"),
-            )
-
-        # Run the appropriate check
-        if check_type == "https":
-            decision = enforcer.check_https(
-                dst_ip=check["dst_ip"],
-                dst_port=check["dst_port"],
-                sni=check.get("sni"),
-                proc=proc,
-                can_mitm=check.get("can_mitm", False),
-            )
-        elif check_type == "http":
-            decision = enforcer.check_http(
-                dst_ip=check["dst_ip"],
-                dst_port=check["dst_port"],
-                url=check["url"],
-                method=check["method"],
-                proc=proc,
-            )
-        elif check_type == "tcp":
-            decision = enforcer.check_tcp(
-                dst_ip=check["dst_ip"],
-                dst_port=check["dst_port"],
-                proc=proc,
-            )
-        elif check_type == "dns":
-            decision = enforcer.check_dns(
-                dst_ip=check["dst_ip"],
-                dst_port=check["dst_port"],
-                query_name=check["query_name"],
-                proc=proc,
-            )
-        elif check_type == "udp":
-            decision = enforcer.check_udp(
-                dst_ip=check["dst_ip"],
-                dst_port=check["dst_port"],
-                proc=proc,
-            )
-        else:
-            pytest.fail(f"Unknown check type: {check_type}")
-
-        # Verify verdict
-        expected_verdict = check["verdict"]
-        actual_verdict = "allow" if decision.allowed else "block"
-
-        assert actual_verdict == expected_verdict, (
-            f"Scenario '{scenario['name']}', check {i} ({check_type}):\n"
-            f"Check: {check}\n"
-            f"Expected: {expected_verdict}, Got: {actual_verdict}\n"
-            f"Reason: {decision.reason}"
-        )
-
-        # Check passthrough flag if specified in fixture
-        if "passthrough" in check:
-            expected_passthrough = check["passthrough"]
-            assert decision.passthrough == expected_passthrough, (
-                f"Scenario '{scenario['name']}', check {i} ({check_type}):\n"
-                f"Check: {check}\n"
-                f"Expected passthrough: {expected_passthrough}, Got: {decision.passthrough}"
-            )
-
-
-# =============================================================================
 # Placeholder Substitution Tests
 # =============================================================================
 
@@ -485,29 +301,91 @@ POST https://github.com/{owner}/{repo}/git-upload-pack
         assert "{repo}" not in result
 
 
-class TestUnknownAttributes:
-    """Defense-in-depth: match_attrs rejects unknown attribute keys."""
+# =============================================================================
+# rule_to_dict Tests
+# =============================================================================
 
-    def test_unknown_key_returns_false(self):
-        from proxy.policy.matcher import match_attrs, ConnectionEvent
-        from proxy.policy.types import Rule
 
-        rule = Rule(
-            type="host",
-            target="github.com",
-            port=[443],
-            protocol="tcp",
-            methods=None,
-            url_base=None,
-            attrs={"typo": "foo"},
-        )
-        event = ConnectionEvent(
-            type="https",
-            dst_ip="140.82.121.4",
-            dst_port=443,
-            host="github.com",
-        )
-        assert not match_attrs(rule, event)
+class TestRuleToDict:
+    """Tests for rule_to_dict serialization."""
+
+    def test_dump_simple_rules(self):
+        """Dump simple host and IP rules."""
+        policy = """
+        github.com
+        *.github.com
+        8.8.8.8:53/udp
+        """
+        rules = parse_policy(policy)
+        dumped = [rule_to_dict(r) for r in rules]
+
+        assert len(dumped) == 3
+
+        # First rule: exact host
+        assert dumped[0]["type"] == "host"
+        assert dumped[0]["target"] == "github.com"
+        assert dumped[0]["port"] == [443]
+        assert dumped[0]["protocol"] == "tcp"
+
+        # Second rule: wildcard host
+        assert dumped[1]["type"] == "wildcard_host"
+        assert dumped[1]["target"] == "*.github.com"
+
+        # Third rule: IP with UDP
+        assert dumped[2]["type"] == "ip"
+        assert dumped[2]["target"] == "8.8.8.8"
+        assert dumped[2]["port"] == [53]
+        assert dumped[2]["protocol"] == "udp"
+
+    def test_dump_url_rules(self):
+        """Dump URL and path rules."""
+        policy = """
+        [https://api.github.com]
+        GET /repos/*/releases
+        POST /repos/*/issues
+        """
+        rules = parse_policy(policy)
+        dumped = [rule_to_dict(r) for r in rules]
+
+        assert len(dumped) == 2
+
+        # GET path rule
+        assert dumped[0]["type"] == "path"
+        assert dumped[0]["target"] == "/repos/*/releases"
+        assert dumped[0]["methods"] == ["GET"]
+        assert dumped[0]["url_base"] == "https://api.github.com"
+
+        # POST path rule
+        assert dumped[1]["type"] == "path"
+        assert dumped[1]["target"] == "/repos/*/issues"
+        assert dumped[1]["methods"] == ["POST"]
+
+    def test_dump_rules_with_attrs(self):
+        """Dump rules with attributes."""
+        policy = """
+        github.com exe=/usr/bin/git
+        """
+        rules = parse_policy(policy)
+        dumped = [rule_to_dict(r) for r in rules]
+
+        assert len(dumped) == 1
+        assert dumped[0]["attrs"] == {"exe": "/usr/bin/git"}
+
+    def test_dump_is_json_serializable(self):
+        """Dumped rules can be serialized to JSON."""
+        policy = """
+        github.com
+        [https://api.github.com]
+        GET /repos/*
+        """
+        rules = parse_policy(policy)
+        dumped = [rule_to_dict(r) for r in rules]
+
+        # Should not raise
+        json_str = json.dumps(dumped)
+        parsed = json.loads(json_str)
+
+        assert len(parsed) == 2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Completes the test restructuring from #127.

- **Split `test_policy.py`** (515-line grab-bag) into 3 focused files that map 1:1 to source modules:
  - `test_policy_parser.py` — flatten, DefaultContext, placeholders, `rule_to_dict`
  - `test_policy_matcher.py` — YAML fixture match verdicts, unknown attributes
  - `test_policy_enforcer.py` — YAML fixture enforcer scenarios
- **Moved `TestDumpRules`** from `test_policy_cli.py` to `test_policy_parser.py` (tests `parse_policy` + `rule_to_dict`, not CLI code)
- **Deleted `test_policy.py`** — all content moved to the above files

### Test file → source module mapping (after both PRs)

| Test file | Source module |
|---|---|
| `test_policy_parser.py` | `proxy/policy/parser.py` |
| `test_policy_matcher.py` | `proxy/policy/matcher.py` |
| `test_policy_enforcer.py` | `proxy/policy/enforcer.py` |
| `test_dns_cache.py` | `proxy/policy/dns_cache.py` |
| `test_policy_defaults.py` | `proxy/policy/defaults.py` |
| `test_policy_grammar.py` | PEG grammar |
| `test_policy_properties.py` | Cross-cutting property tests |
| `test_policy_cli.py` | `proxy/cli.py` |

## Test plan

- [x] 779 tests pass (same count as before — no tests lost or gained)

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)