### PR TITLE
Add Azure IMDS to default policy

### DIFF
--- a/src/proxy/policy/defaults.py
+++ b/src/proxy/policy/defaults.py
@@ -27,9 +27,13 @@ DEFAULT_POLICY = """
 # only domains allowed by other rules can be resolved.
 127.0.0.53:53/udp
 
-# Azure wireserver (metadata/heartbeat for GitHub-hosted runners)
-# The WALinuxAgent runs in the background and must access the wireserver.
-168.63.129.16:80|32526 cgroup=/azure.slice/walinuxagent.service
+# Azure infrastructure (WALinuxAgent on GitHub-hosted runners)
+# The WALinuxAgent runs in the background and must reach the wireserver
+# (metadata/heartbeat) and IMDS (instance metadata).
+[cgroup=/azure.slice/walinuxagent.service]
+168.63.129.16:80|32526
+169.254.169.254:80
+[]
 
 # GitHub Actions results receiver (job status reporting)
 # Various runner processes (Runner.Worker, action node processes) need this.

--- a/tests/test_policy_defaults.py
+++ b/tests/test_policy_defaults.py
@@ -100,6 +100,40 @@ class TestAzureWireserverRules:
         assert not allowed
 
 
+class TestAzureImdsRules:
+    """Test Azure IMDS rules for WALinuxAgent."""
+
+    def test_allows_azure_agent_to_imds(self):
+        """Should allow Azure Linux Agent to access IMDS."""
+        matcher = PolicyMatcher(DEFAULT_POLICY)
+        event = ConnectionEvent(
+            type="http",
+            dst_ip="169.254.169.254",
+            dst_port=80,
+            url="http://169.254.169.254/metadata/instance?api-version=2021-02-01",
+            method="GET",
+            exe="/usr/bin/python3.12",
+            cgroup="/azure.slice/walinuxagent.service",
+        )
+        allowed, _ = matcher.match(event)
+        assert allowed
+
+    def test_blocks_non_azure_cgroup_to_imds(self):
+        """Should block non-Azure cgroup processes from IMDS."""
+        matcher = PolicyMatcher(DEFAULT_POLICY)
+        event = ConnectionEvent(
+            type="http",
+            dst_ip="169.254.169.254",
+            dst_port=80,
+            url="http://169.254.169.254/metadata/instance?api-version=2021-02-01",
+            method="GET",
+            exe="/usr/bin/curl",
+            cgroup="/system.slice/hosted-compute-agent.service",
+        )
+        allowed, _ = matcher.match(event)
+        assert not allowed
+
+
 class TestResultsReceiverRules:
     """Test GitHub Actions results receiver rules."""
 


### PR DESCRIPTION
## Summary
- Allow WALinuxAgent to reach the IMDS endpoint (`169.254.169.254:80`), scoped to `cgroup=/azure.slice/walinuxagent.service`
- Refactor wireserver + IMDS rules under a shared `[cgroup=...]` header instead of inline attributes

## Test plan
- [x] New tests: allow WALinuxAgent cgroup, block runner cgroup from IMDS
- [x] Existing wireserver tests still pass (header refactor is transparent)
- [x] Full test suite passes (656 tests)

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)