### PR TITLE
Make passthrough rules implicitly allow connections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ Rule types: hostname (`github.com`), wildcard (`*.github.com`, `derp*.tailscale.
 
 Attributes: `exe=`, `cgroup=`, `step=`, `action=`, `image=`, `arg=`, `arg[N]=`. Port: `:443`, `:80|443`, `:*`. Protocol: `/tcp`, `/udp`. Methods: `GET|POST`.
 
-TLS passthrough: `passthrough` keyword on host/wildcard rules (`github.com passthrough`) or in header context (`[passthrough]`). Evaluated as a separate phase after allow/deny — connection must be allowed first, then passthrough rules skip MITM. Only host/wildcard types supported (IP/CIDR/URL/dns: rejected). In `tls_clienthello`, sets `ignore_connection=True` and logs with `passthrough=True`.
+TLS passthrough: `passthrough` keyword on host/wildcard rules (`github.com passthrough`) or in header context (`[passthrough]`). Passthrough rules implicitly allow the connection and skip MITM — no separate allow rule needed. Only host/wildcard types supported (IP/CIDR/URL/dns: rejected). In `tls_clienthello`, sets `ignore_connection=True` and logs with `passthrough=True`.
 
 The `for_runner` factory prepends infrastructure defaults and injects `cgroup=/system.slice/hosted-compute-agent.service` on all rules.
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ policy: |
 
 ### TLS Passthrough
 
-Some services use certificate pinning or embedded trust stores that reject the MITM proxy's CA certificate. The `passthrough` keyword skips TLS interception for matching connections while still enforcing the allow policy:
+Some services use certificate pinning or embedded trust stores that reject the MITM proxy's CA certificate. The `passthrough` keyword allows the connection and skips TLS interception — no separate allow rule is needed:
 
 ```yaml
 policy: |
@@ -185,7 +185,7 @@ policy: |
   auth.example.com
 ```
 
-Passthrough is evaluated as a separate phase — a connection must first match an allow rule, then passthrough rules are checked independently. This means you need both an allow rule and a passthrough rule (or use the same hostname for both). Only hostname and wildcard rules support passthrough; IP, CIDR, URL, and DNS-only rules do not.
+A passthrough rule implicitly allows the connection and skips TLS interception. Only hostname and wildcard rules support passthrough; IP, CIDR, URL, and DNS-only rules do not.
 
 ### Process Scope Constraints
 

--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -141,15 +141,14 @@ normal-host.com
 
 **How it works:**
 
-1. A connection must first match an allow rule (hostname, wildcard, IP, etc.)
-2. Passthrough rules are evaluated as a separate phase — if the allowed connection also matches a passthrough rule, TLS interception is skipped
+1. A passthrough rule implicitly allows the connection — no separate allow rule is needed
+2. If the connection also matches a passthrough rule, TLS interception is skipped
 3. The connection is still logged (with `passthrough: true`) but the proxy does not decrypt it
 
 **Restrictions:**
 
 - Only `host` and `wildcard_host` rules support passthrough. IP, CIDR, URL, path, and DNS-only rules with `passthrough` are rejected at validation time and silently dropped at runtime.
 - Passthrough only applies at the TLS stage (`tls_clienthello`). Since TLS is not decrypted, URL path matching and HTTP method filtering are not available for passthrough connections.
-- A passthrough-only rule (without a matching allow rule) does not allow the connection — the connection must be allowed first.
 
 ### Placeholders
 

--- a/docs/policy-syntax-design.md
+++ b/docs/policy-syntax-design.md
@@ -153,8 +153,7 @@ Design document for the egress filter allowlist/blocklist syntax.
     - `github.com passthrough` - per-rule passthrough
     - `[passthrough]` - header context for multiple rules
     - `[passthrough cgroup=@docker]` - header context with attributes
-    - Two-phase evaluation: connection must match an allow rule first, then passthrough rules are checked independently
-    - Passthrough-only rules (without a matching allow rule) do not allow the connection
+    - Passthrough rules implicitly allow the connection — no separate allow rule needed
     - Only valid on `host` and `wildcard_host` rule types — IP, CIDR, URL, path, and dns: rules with passthrough are rejected at validation time and silently dropped at runtime (logged at DEBUG)
     - Rationale: passthrough operates at the TLS layer (SNI only), so it can only match hostnames. URL/path rules require MITM to inspect, which contradicts passthrough's purpose
     - In `tls_clienthello`, `data.ignore_connection = True` tells mitmproxy to skip interception — `request()` never fires

--- a/src/proxy/policy/matcher.py
+++ b/src/proxy/policy/matcher.py
@@ -588,7 +588,7 @@ class PolicyMatcher:
             defaults: Optional DefaultContext to override security defaults.
         """
         all_rules = parse_policy(policy_text, defaults=defaults)
-        self.rules = [r for r in all_rules if not r.passthrough]
+        self.rules = list(all_rules)
         self.passthrough_rules = [r for r in all_rules if r.passthrough]
 
     def match(self, event: ConnectionEvent | dict) -> tuple[bool, int | None]:

--- a/tests/fixtures/policy_enforcer.yaml
+++ b/tests/fixtures/policy_enforcer.yaml
@@ -921,7 +921,6 @@ tests:
 
   - name: Passthrough rule sets decision.passthrough when allowed and can_mitm
     policy: |
-      github.com
       github.com passthrough
     checks:
       - type: https
@@ -934,7 +933,6 @@ tests:
 
   - name: Passthrough without can_mitm does not set passthrough
     policy: |
-      github.com
       github.com passthrough
     checks:
       - type: https
@@ -956,7 +954,7 @@ tests:
         verdict: allow
         passthrough: false
 
-  - name: Passthrough-only rule without allow rule means blocked
+  - name: Passthrough rule implicitly allows
     policy: |
       example.com passthrough
     checks:
@@ -965,7 +963,8 @@ tests:
         dst_ip: 93.184.216.34
         dst_port: 443
         can_mitm: true
-        verdict: block
+        verdict: allow
+        passthrough: true
 
   - name: Passthrough with scoped cgroup attr matches
     policy: |
@@ -996,7 +995,6 @@ tests:
 
   - name: Passthrough wildcard rule
     policy: |
-      *.docker.io
       *.docker.io passthrough
     checks:
       - type: https


### PR DESCRIPTION
## Summary
- Passthrough rules now implicitly allow connections — no separate allow rule needed
- Previously, a passthrough rule only controlled TLS MITM bypass and required a duplicate allow rule, which was confusing (a passthrough-only rule silently blocked)
- The implementation adds passthrough rules to both `self.rules` (allow matching) and `self.passthrough_rules` (MITM bypass checking), keeping the existing two-phase enforcement flow

## Test plan
- [x] All 489 policy tests pass (parser, matcher, CLI, enforcer)
- [x] Updated enforcer fixtures: removed redundant duplicate allow rules, flipped "passthrough-only means blocked" to expect allow
- [x] Verified scoped passthrough (e.g. `cgroup=@docker`) still works correctly with a separate broad allow rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)