### PR TITLE
Add wildcard and multi-port support to URL rules

### DIFF
--- a/tests/fixtures/policy_flatten.yaml
+++ b/tests/fixtures/policy_flatten.yaml
@@ -1492,3 +1492,57 @@ tests:
         url_base: null
         attrs: {}
         insecure: true
+
+  # =============================================================================
+  # URL rules with wildcard and multi-port
+  # =============================================================================
+
+  - name: URL with wildcard port
+    policy: |
+      https://example.com:*/api/*
+    rules:
+      - type: url
+        target: "https://example.com:*/api/*"
+        port: "*"
+        protocol: tcp
+        methods: ["GET", "HEAD"]
+        url_base: null
+        attrs: {}
+
+  - name: URL with multi-port
+    policy: |
+      http://example.com:80|8080/path
+    rules:
+      - type: url
+        target: "http://example.com:80|8080/path"
+        port: [80, 8080]
+        protocol: tcp
+        methods: ["GET", "HEAD"]
+        url_base: null
+        attrs: {}
+
+  - name: URL base header with wildcard port
+    policy: |
+      [https://example.com:*]
+      GET /api/*
+    rules:
+      - type: path
+        target: "/api/*"
+        port: "*"
+        protocol: tcp
+        methods: ["GET"]
+        url_base: "https://example.com:*"
+        attrs: {}
+
+  - name: URL base header with multi-port
+    policy: |
+      [http://example.com:80|8080]
+      GET /api/*
+    rules:
+      - type: path
+        target: "/api/*"
+        port: [80, 8080]
+        protocol: tcp
+        methods: ["GET"]
+        url_base: "http://example.com:80|8080"
+        attrs: {}

--- a/tests/fixtures/policy_match.yaml
+++ b/tests/fixtures/policy_match.yaml
@@ -1660,3 +1660,67 @@ tests:
           host: github.com
           image: "ghcr.io/other/myapp:latest"
         verdict: block
+
+  # =============================================================================
+  # URL rules with wildcard and multi-port
+  # =============================================================================
+
+  - name: URL rule with wildcard port matches any port
+    policy: |
+      https://example.com:*/api/*
+    connections:
+      - event:
+          type: http
+          dst_ip: 93.184.216.34
+          dst_port: 443
+          url: https://example.com/api/data
+          method: GET
+        verdict: allow
+      - event:
+          type: http
+          dst_ip: 93.184.216.34
+          dst_port: 8080
+          url: https://example.com:8080/api/data
+          method: GET
+        verdict: allow
+      - event:
+          type: http
+          dst_ip: 93.184.216.34
+          dst_port: 9999
+          url: https://example.com:9999/api/data
+          method: GET
+        verdict: allow
+      # POST not allowed (default methods are GET|HEAD)
+      - event:
+          type: http
+          dst_ip: 93.184.216.34
+          dst_port: 443
+          url: https://example.com/api/data
+          method: POST
+        verdict: block
+
+  - name: URL rule with multi-port matches listed ports only
+    policy: |
+      http://example.com:80|8080/api/*
+    connections:
+      - event:
+          type: http
+          dst_ip: 93.184.216.34
+          dst_port: 80
+          url: http://example.com/api/data
+          method: GET
+        verdict: allow
+      - event:
+          type: http
+          dst_ip: 93.184.216.34
+          dst_port: 8080
+          url: http://example.com:8080/api/data
+          method: GET
+        verdict: allow
+      - event:
+          type: http
+          dst_ip: 93.184.216.34
+          dst_port: 9090
+          url: http://example.com:9090/api/data
+          method: GET
+        verdict: block

--- a/tests/test_policy_grammar.py
+++ b/tests/test_policy_grammar.py
@@ -36,7 +36,7 @@ rule            = ws* (url_rule / path_rule / cidr_rule / ip_rule / host_rule) p
 url_rule        = (method_attr ws+)? scheme "://" url_host url_port? url_path
 url_host        = ipv4 / wildcard_host / hostname
 scheme          = "https" / "http"
-url_port        = ":" port_value
+url_port        = ":" port_list
 url_path        = "/" path_rest
 path_rest       = ~"[a-zA-Z0-9_.~*/%+-]*"
 
@@ -161,6 +161,8 @@ VALID_RULES = [
     "* https://example.com/*",
     # URLs with ports
     "https://example.com:8080/api/*",
+    "https://example.com:*/api/*",
+    "https://example.com:80|443/api/*",
     # Headers
     "[:443]",
     "[:22]",


### PR DESCRIPTION
## Summary

- Reuse the existing `port_list` grammar for `url_port`, enabling `*` (wildcard) and `80|443` (multi-port) syntax in URL rules and URL base headers
- Previously URL rules only accepted single numeric ports (e.g., `:8080`), while hostname rules already supported wildcards and multi-port — this makes port syntax consistent across rule types
- Fix `visit_header` to use pre-parsed port from the grammar visitor instead of `urlparse().port`, which crashes on non-numeric ports like `*`

## Test plan

- [x] All 562 existing tests pass (grammar, flatten, matcher)
- [x] New grammar tests: `https://example.com:*/api/*` and `https://example.com:80|443/api/*` parse successfully
- [x] New flatten tests: URL wildcard port → `port: "*"`, URL multi-port → `port: [80, 8080]`, URL base headers with wildcard/multi-port
- [x] New match tests: wildcard port matches any port, multi-port matches listed ports only and blocks others

🤖 Generated with [Claude Code](https://claude.com/claude-code)