### PR TITLE
Fix runner environment validation on updated runner images

### DIFF
--- a/src/proxy/logging.py
+++ b/src/proxy/logging.py
@@ -30,6 +30,12 @@ def init_logging() -> logging.Logger:
     handler.setFormatter(logging.Formatter('%(asctime)s %(message)s'))
     logger.addHandler(handler)
 
+    # Also send ERROR+ to stderr so startup failures appear in supervisor output
+    stderr_handler = logging.StreamHandler()
+    stderr_handler.setLevel(logging.ERROR)
+    stderr_handler.setFormatter(logging.Formatter('%(message)s'))
+    logger.addHandler(stderr_handler)
+
     # Connection events file (JSONL format, line-buffered)
     _conn_file = open(CONNECTIONS_FILE, "a", buffering=1)
 

--- a/src/proxy/policy/__init__.py
+++ b/src/proxy/policy/__init__.py
@@ -1,7 +1,7 @@
 """Policy parsing and matching engine."""
 
 from .defaults import RUNNER_DEFAULTS
-from .gha import NODE24_EXE, RUNNER_CGROUP, RUNNER_WORKER_EXE
+from .gha import RUNNER_CGROUP, is_node24, is_runner_worker
 from .dns_cache import DNSIPCache
 from .enforcer import Decision, PolicyEnforcer, ProcessInfo, Verdict
 from .matcher import ConnectionEvent, PolicyMatcher, match_rule
@@ -28,9 +28,9 @@ __all__ = [
     "HeaderContext",
     "DefaultContext",
     "SECURE_DEFAULTS",
-    "NODE24_EXE",
     "RUNNER_CGROUP",
-    "RUNNER_WORKER_EXE",
+    "is_node24",
+    "is_runner_worker",
     "RUNNER_DEFAULTS",
     # Parser
     "parse_policy",

--- a/src/proxy/policy/gha.py
+++ b/src/proxy/policy/gha.py
@@ -49,10 +49,18 @@ def validate_runner_environment() -> list[str]:
     worker_idx = exe_paths.index(RUNNER_WORKER_EXE) if RUNNER_WORKER_EXE in exe_paths else -1
 
     if node24_idx != 4:
-        errors.append(f"node24 at index {node24_idx}, expected 4")
+        actual_at_4 = exe_paths[4] if len(exe_paths) > 4 else "<missing>"
+        errors.append(
+            f"node24 at index {node24_idx}, expected 4"
+            f" (index 4 is {actual_at_4}; ancestry: {exe_paths})"
+        )
 
     if worker_idx != 5:
-        errors.append(f"Runner.Worker at index {worker_idx}, expected 5")
+        actual_at_5 = exe_paths[5] if len(exe_paths) > 5 else "<missing>"
+        errors.append(
+            f"Runner.Worker at index {worker_idx}, expected 5"
+            f" (index 5 is {actual_at_5}; ancestry: {exe_paths})"
+        )
 
     # Check cgroup of Runner.Worker (proxy itself runs in its own scope)
     if worker_idx >= 0:

--- a/src/proxy/policy/gha.py
+++ b/src/proxy/policy/gha.py
@@ -13,9 +13,10 @@ import re
 # Used to distinguish runner processes from Docker containers, Azure agent, etc.
 RUNNER_CGROUP = "/system.slice/hosted-compute-agent.service"
 
-# Runner exe paths vary by installation method: "cached", "extracted", or
-# a version directory like "2.331.0". Match the stable prefix + suffix.
-_RUNNER_BASE = r"/home/runner/actions-runner/[^/]+/"
+# Runner exe paths vary by installation method: "cached", "extracted", a
+# version directory like "2.331.0", or nested like "cached/2.334.0".
+# Match the stable prefix + suffix with one or more directories between.
+_RUNNER_BASE = r"/home/runner/actions-runner/(?:[^/]+/)+"
 _RUNNER_WORKER_RE = re.compile(_RUNNER_BASE + r"bin/Runner\.Worker$")
 _NODE24_RE = re.compile(_RUNNER_BASE + r"externals/node24/bin/node$")
 

--- a/src/proxy/policy/gha.py
+++ b/src/proxy/policy/gha.py
@@ -7,18 +7,25 @@ of any specific action. They're used for:
 """
 
 import os
+import re
 
 # Cgroup path for processes in the runner's process tree
 # Used to distinguish runner processes from Docker containers, Azure agent, etc.
 RUNNER_CGROUP = "/system.slice/hosted-compute-agent.service"
 
-# Full path to the Runner.Worker executable
-# This process spawns each step and sets GITHUB_* env vars in children
-RUNNER_WORKER_EXE = "/home/runner/actions-runner/cached/bin/Runner.Worker"
+# Runner exe paths vary by installation method: "cached", "extracted", or
+# a version directory like "2.331.0". Match the stable prefix + suffix.
+_RUNNER_BASE = r"/home/runner/actions-runner/[^/]+/"
+_RUNNER_WORKER_RE = re.compile(_RUNNER_BASE + r"bin/Runner\.Worker$")
+_NODE24_RE = re.compile(_RUNNER_BASE + r"externals/node24/bin/node$")
 
-# Node.js executable path for actions using node24 runtime
-# Must match the 'using' field in action.yml
-NODE24_EXE = "/home/runner/actions-runner/cached/externals/node24/bin/node"
+
+def is_runner_worker(exe: str) -> bool:
+    return _RUNNER_WORKER_RE.match(exe) is not None
+
+
+def is_node24(exe: str) -> bool:
+    return _NODE24_RE.match(exe) is not None
 
 
 def validate_runner_environment() -> list[str]:
@@ -44,9 +51,9 @@ def validate_runner_environment() -> list[str]:
     ancestry = get_process_ancestry(os.getpid(), max_depth=10)
     exe_paths = [exe for _, exe in ancestry]
 
-    # Expected positions (strict - no tolerance)
-    node24_idx = exe_paths.index(NODE24_EXE) if NODE24_EXE in exe_paths else -1
-    worker_idx = exe_paths.index(RUNNER_WORKER_EXE) if RUNNER_WORKER_EXE in exe_paths else -1
+    # Find positions by pattern match
+    node24_idx = next((i for i, exe in enumerate(exe_paths) if is_node24(exe)), -1)
+    worker_idx = next((i for i, exe in enumerate(exe_paths) if is_runner_worker(exe)), -1)
 
     if node24_idx != 4:
         actual_at_4 = exe_paths[4] if len(exe_paths) > 4 else "<missing>"

--- a/src/proxy/proc.py
+++ b/src/proxy/proc.py
@@ -7,7 +7,7 @@ import re
 import socket
 from pathlib import Path
 
-from proxy.policy.gha import RUNNER_CGROUP, RUNNER_WORKER_EXE
+from proxy.policy.gha import RUNNER_CGROUP, is_runner_worker
 
 
 # =============================================================================
@@ -217,10 +217,10 @@ def find_trusted_github_pids(pid: int) -> list[int]:
 
     ancestry = get_process_ancestry(pid)
 
-    # Find Runner.Worker in ancestry (using full exe path to prevent spoofing)
+    # Find Runner.Worker in ancestry (using exe path pattern to prevent spoofing)
     runner_idx = None
     for i, (p, exe) in enumerate(ancestry):
-        if exe == RUNNER_WORKER_EXE:
+        if is_runner_worker(exe):
             runner_idx = i
             break
 

--- a/tests/test_gha.py
+++ b/tests/test_gha.py
@@ -1,0 +1,51 @@
+"""Tests for GitHub runner environment exe path patterns."""
+
+import pytest
+
+from proxy.policy.gha import is_node24, is_runner_worker
+
+
+# Layouts observed on GitHub-hosted runners over time
+OBSERVED_BASES = [
+    "/home/runner/actions-runner/cached/",       # original layout
+    "/home/runner/actions-runner/extracted/",    # alternate install method
+    "/home/runner/actions-runner/2.331.0/",      # version directory
+    "/home/runner/actions-runner/cached/2.334.0/",  # nested (runner >= 2.334)
+]
+
+
+@pytest.mark.parametrize("base", OBSERVED_BASES)
+def test_runner_worker_matches_observed_layouts(base):
+    assert is_runner_worker(base + "bin/Runner.Worker")
+
+
+@pytest.mark.parametrize("base", OBSERVED_BASES)
+def test_node24_matches_observed_layouts(base):
+    assert is_node24(base + "externals/node24/bin/node")
+
+
+@pytest.mark.parametrize(
+    "exe",
+    [
+        "/home/runner/actions-runner/bin/Runner.Worker",  # no intermediate dir
+        "/home/runner/actions-runner/cached/bin/Runner.Listener",
+        "/tmp/home/runner/actions-runner/cached/bin/Runner.Worker",  # wrong prefix
+        "/home/runner/actions-runner/cached/bin/Runner.Workers",  # suffix overrun
+        "",
+    ],
+)
+def test_runner_worker_rejects(exe):
+    assert not is_runner_worker(exe)
+
+
+@pytest.mark.parametrize(
+    "exe",
+    [
+        "/home/runner/actions-runner/externals/node24/bin/node",  # no intermediate dir
+        "/home/runner/actions-runner/cached/externals/node20/bin/node",  # wrong node version
+        "/usr/bin/node",
+        "",
+    ],
+)
+def test_node24_rejects(exe):
+    assert not is_node24(exe)


### PR DESCRIPTION
## Summary

Integration tests on the `test` branch were failing across the board: the proxy died at startup with

```
Runner environment validation failed: node24 at index -1, expected 4
Runner environment validation failed: Runner.Worker at index -1, expected 5
```

Two layers to the fix:

1. Three commits originally validated on the `test` branch in March (never merged): log proxy errors to stderr, include actual ancestry in validation errors, and match runner exe paths by pattern instead of exact string (paths vary by install method: `cached`, `extracted`, version dirs).

2. A new commit extending the pattern to allow nested directories: current runner images (2.334+) use `/home/runner/actions-runner/cached/2.334.0/bin/Runner.Worker`, which the single-segment pattern from March didn't match. Adds unit tests covering all observed layouts.

The trust model is unchanged: spoof resistance comes from the runner-cgroup check plus the ancestry walk in `find_trusted_github_pids`, not from the exact exe string (the `actions-runner` directory is runner-writable either way).

## Test plan

- [x] 923 local unit tests pass (17 new)
- [x] All 12 integration test workflows pass on the `test` branch (including Docker image attribution, which was failing back in March)
- Note: `Test insecure flag` failed once with a 502 from `expired.badssl.com` and passed on rerun — transient badssl.com flakiness, not related to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)