### PR TITLE
Recover NAT-mangled connections in PID attribution via conntrack

### DIFF
--- a/.github/workflows/test-attribution-stress.yml
+++ b/.github/workflows/test-attribution-stress.yml
@@ -1,0 +1,159 @@
+name: Test attribution under NAT mangling
+
+# Efficiently and deterministically triggers iptables REDIRECT source-port
+# mangling (the cause of dropped PID attribution) and verifies the conntrack
+# reversal recovers it.
+#
+# Two ideas make this fast and reliable vs. brute-forcing thousands of curls:
+#   1. Shrink the ephemeral port range so concurrent connections to different
+#      destinations are *forced* to reuse source ports — which is exactly what
+#      makes netfilter remap (mangle) them. Mangling becomes deterministic
+#      with a few hundred connections instead of thousands.
+#   2. Run in enforcement mode and send only a TLS ClientHello to many
+#      distinct routable destinations. The proxy blocks at tls_clienthello
+#      (logging the PID it resolved) without needing a full handshake or a
+#      reachable upstream — the connect() just needs a route so the SYN is
+#      generated and REDIRECTed to the proxy.
+
+on:
+  push:
+    branches: [test]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  stress:
+    runs-on: ubuntu-latest
+    timeout-minutes: 6
+    steps:
+      - name: Setup egress filter (enforcement)
+        uses: gregclermont/egress-filter@test
+        # Enforcement so blocked connections are logged (with PID) at
+        # tls_clienthello. Default policy still allows runner infrastructure.
+
+      - name: Stress attribution with deterministic source-port collisions
+        run: |
+          python3 - <<'PY'
+          import socket, ssl, time
+
+          # Routable public ranges (Cloudflare / Google). We never actually talk
+          # to them — connect() just needs a route so the SYN is generated and
+          # REDIRECTed to the proxy, which blocks at the ClientHello.
+          DESTS = ([f"1.1.1.{i}" for i in range(1, 255)]
+                   + [f"8.8.8.{i}" for i in range(1, 255)])
+
+          # Craft a ClientHello once (with SNI) via an in-memory TLS handshake.
+          ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+          ctx.check_hostname = False
+          ctx.verify_mode = ssl.CERT_NONE
+          inbio, outbio = ssl.MemoryBIO(), ssl.MemoryBIO()
+          sslobj = ctx.wrap_bio(inbio, outbio, server_hostname="stress.invalid")
+          try:
+              sslobj.do_handshake()
+          except ssl.SSLWantReadError:
+              pass
+          client_hello = outbio.read()
+          print(f"ClientHello: {len(client_hello)} bytes")
+
+          # Deterministically trigger mangling WITHOUT saturating the box (which
+          # would make the kernel's own SO_ORIGINAL_DST unreliable, unlike the
+          # ~1% effect seen in production). Each pair binds two sockets to the
+          # SAME source port and connects them to DIFFERENT destinations: after
+          # REDIRECT both collapse onto (client:port -> 127.0.0.1:8080), so the
+          # second collides and netfilter remaps its source port. The global
+          # ephemeral range is left untouched.
+          N_PAIRS = 120
+          BOUND_LO = 30000
+          socks = []
+          for i in range(N_PAIRS):
+              port = BOUND_LO + i
+              for j in range(2):
+                  s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                  s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                  try:
+                      s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+                  except OSError:
+                      pass
+                  try:
+                      s.bind(("", port))
+                  except OSError:
+                      s.close()
+                      continue
+                  s.setblocking(False)
+                  s.connect_ex((DESTS[(2 * i + j) % len(DESTS)], 443))
+                  socks.append(s)
+          time.sleep(0.5)  # let the (local) connects complete
+          for s in socks:
+              try:
+                  s.send(client_hello)  # triggers tls_clienthello -> block+log
+              except OSError:
+                  pass
+          time.sleep(1.0)  # hold concurrently so the collisions are live
+          for s in socks:
+              s.close()
+          print(f"total opened: {len(socks)} ({N_PAIRS} collision pairs)")
+          PY
+
+      - name: Analyze attribution (NAT-aware)
+        if: always()
+        run: |
+          python3 - <<'PY'
+          import json
+
+          # Connections we bound use source ports in this range; anything
+          # outside it can only be a netfilter-remapped (mangled) port.
+          BOUND_LO, BOUND_HI = 30000, 30119
+
+          total = mangled = mangled_attributed = unattributed = 0
+          unattributed_samples = []
+          for line in open("${{ runner.temp }}/connections.jsonl"):
+              c = json.loads(line)
+              # Our stress connections are uniquely tagged by their SNI.
+              if c.get("host") != "stress.invalid":
+                  continue
+              total += 1
+              sp = c.get("src_port")
+              attributed = c.get("pid") is not None
+              # A source port outside our bound range is netfilter-remapped ->
+              # direct proof that mangling actually happened.
+              is_mangled = sp is not None and not (BOUND_LO <= sp <= BOUND_HI)
+              if is_mangled:
+                  mangled += 1
+                  if attributed:
+                      mangled_attributed += 1
+              if not attributed:
+                  unattributed += 1
+                  if len(unattributed_samples) < 5:
+                      unattributed_samples.append({"dst_ip": c.get("dst_ip"), "src_port": sp})
+
+          print(f"total connections to TEST-NET : {total}")
+          print(f"  NAT-mangled (proof of bug)  : {mangled}")
+          print(f"  mangled AND attributed      : {mangled_attributed}")
+          print(f"  unattributed (pid=null)     : {unattributed}")
+          if unattributed_samples:
+              print(f"  unattributed samples        : {unattributed_samples}")
+
+          if total == 0:
+              print("::error::No stress connections were logged — test did not exercise the path.")
+              raise SystemExit(1)
+          if mangled == 0:
+              print("::warning::No source-port mangling observed; test inconclusive "
+                    "(shrink the port range further or raise concurrency).")
+
+          # With the conntrack reversal, mangled connections must still be
+          # attributed. Allow a little slack for genuinely racy edge cases.
+          threshold = max(3, total // 100)
+          if unattributed > threshold:
+              print(f"::error::{unattributed}/{total} connections unattributed "
+                    f"(threshold {threshold}) — NAT reversal not recovering mangled connections.")
+              raise SystemExit(1)
+          print(f"PASS: {mangled} mangled connections, only {unattributed} unattributed "
+                "— conntrack reversal recovered them")
+          PY
+
+      - name: Show proxy log
+        if: always()
+        run: tail -40 "${{ runner.temp }}/proxy.log" || echo "No proxy log found"

--- a/src/proxy/bpf.py
+++ b/src/proxy/bpf.py
@@ -36,6 +36,8 @@ class BPFState:
         # DNS 4-tuple cache: (src_port, txid) -> (pid, dst_ip, dst_port)
         # Populated by nfqueue (before NAT), consumed by mitmproxy (after NAT)
         self.dns_cache = {}
+        # Conntrack reverser for NAT source-port mangling (created in setup()).
+        self.conntrack = None
 
     def setup(self):
         """Load and attach BPF programs."""
@@ -65,11 +67,19 @@ class BPFState:
 
         self.map_v4 = self.bpf_obj.maps["conn_to_pid_v4"].typed(key=ConnKeyV4, value=int)
 
+        # NAT reversal for the transparent-proxy miss path (fail-safe if the
+        # library is unavailable).
+        from .conntrack import ConntrackReverser
+        self.conntrack = ConntrackReverser()
+
         proxy_logging.logger.info("BPF loaded and attached")
 
     def cleanup(self):
         """Cleanup BPF resources."""
         proxy_logging.logger.info("Cleaning up BPF...")
+        if self.conntrack:
+            self.conntrack.close()
+            self.conntrack = None
         for link in self.bpf_links:
             try:
                 link.destroy()
@@ -80,7 +90,7 @@ class BPFState:
             self.bpf_obj.__exit__(None, None, None)
 
     def lookup_pid(self, dst_ip: str, src_port: int, dst_port: int, protocol: int = IPPROTO_TCP) -> int | None:
-        """Look up PID from BPF map."""
+        """Look up PID from BPF map by 4-tuple."""
         if not self.map_v4:
             return None
         try:
@@ -93,3 +103,36 @@ class BPFState:
             return self.map_v4.get(key)
         except Exception:
             return None
+
+    def lookup_pid_nat_aware(
+        self,
+        dst_ip: str,
+        dst_port: int,
+        peername: tuple[str, int] | None,
+        protocol: int = IPPROTO_TCP,
+    ) -> int | None:
+        """Look up PID for a transparently-proxied connection, reversing NAT.
+
+        The kprobe records the original (pre-NAT) source port, but iptables
+        REDIRECT can remap the source port under load, so `peername` (what the
+        proxy sees) may not match. We first try the port the proxy sees; on a
+        miss we ask conntrack for the original source port and retry.
+
+        Args:
+            dst_ip, dst_port: original destination (from SO_ORIGINAL_DST).
+            peername: accepted socket's peer address (client_ip, src_port).
+        """
+        src_port = peername[1] if peername else 0
+        pid = self.lookup_pid(dst_ip, src_port, dst_port, protocol)
+        if pid is not None:
+            return pid
+
+        # Miss: the source port was likely NAT-remapped. Recover the original
+        # from conntrack (identified by client address + original destination).
+        if self.conntrack and peername:
+            orig_port = self.conntrack.original_src_port(
+                client=peername, orig_dst=(dst_ip, dst_port), protocol=protocol
+            )
+            if orig_port is not None and orig_port != src_port:
+                return self.lookup_pid(dst_ip, orig_port, dst_port, protocol)
+        return None

--- a/src/proxy/conntrack.py
+++ b/src/proxy/conntrack.py
@@ -1,0 +1,200 @@
+"""Conntrack-based NAT reversal for PID attribution.
+
+The BPF `tcp_connect` kprobe records the connection 4-tuple using the
+*original* (pre-NAT) source port. The transparent-proxy handler, however,
+sees the connection *after* iptables REDIRECT, whose DNAT collapses every
+destination onto the single proxy socket. Under load this triggers
+netfilter source-port remapping, so the proxy's `peername` source port no
+longer matches the port the kprobe recorded — the BPF lookup misses and the
+connection can't be attributed.
+
+This module reverses that translation. Conntrack is the only component that
+knows the original<->remapped mapping, so on a BPF miss we ask it for the
+*original* source port of the connection and the handler re-keys the lookup.
+
+We identify the connection by the fields the proxy knows reliably and that
+together uniquely pin a conntrack entry:
+  - the original source IP and original destination (IP:port), from the
+    accepted socket's peername and SO_ORIGINAL_DST;
+  - the reply tuple's destination port = the (possibly NAT-mangled) source
+    port the proxy sees (peername port).
+
+We find that entry with a filtered table walk and read its original source
+port. Matching on the original destination is what makes this safe: a
+remapped reply port can be shared with an unrelated flow, but only one entry
+has that reply port AND our original destination — so we can never return a
+port belonging to a different destination (worst case: no match, and we
+simply don't attribute, exactly as before this change).
+
+Everything is fail-safe: if the library is missing or any query fails, calls
+return None and attribution falls back to today's BPF-only behavior.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import socket
+
+from . import logging as proxy_logging
+from .utils import ip_to_int, IPPROTO_TCP
+
+# libnetfilter_conntrack constants (stable ABI).
+_CONNTRACK = 1  # NFNL_SUBSYS_CTNETLINK
+
+# enum nf_conntrack_attr
+_ATTR_ORIG_IPV4_SRC = 0
+_ATTR_ORIG_IPV4_DST = 1
+_ATTR_ORIG_PORT_SRC = 8
+_ATTR_ORIG_PORT_DST = 9
+_ATTR_REPL_PORT_DST = 11
+
+# enum nf_conntrack_query
+_NFCT_Q_DUMP = 5
+
+# enum nf_conntrack_msg_type (mask for callback registration)
+_NFCT_T_ALL = 7  # NEW | UPDATE | DESTROY
+
+# enum nf_conntrack_callback return values
+_NFCT_CB_CONTINUE = 1
+_NFCT_CB_STOP = 0
+
+_AF_INET = socket.AF_INET
+
+# C callback signature: int cb(enum msg_type, struct nf_conntrack *, void *data)
+_CALLBACK_T = ctypes.CFUNCTYPE(
+    ctypes.c_int, ctypes.c_int, ctypes.c_void_p, ctypes.c_void_p
+)
+
+
+class ConntrackReverser:
+    """Recover the original source port of a NAT-mangled connection.
+
+    Opens a single netlink handle and reuses it. Intended to be called from
+    the (single-threaded) proxy event loop, only on the BPF-miss path.
+    """
+
+    def __init__(self):
+        self._lib = None
+        self._cb = _CALLBACK_T(self._on_entry)  # keep CFUNCTYPE alive
+        self._criteria = None  # match dict for the in-progress dump
+        self._result = None
+        self.available = False
+        try:
+            self._setup()
+            self.available = True
+        except Exception as e:
+            try:
+                proxy_logging.logger.warning(
+                    f"Conntrack NAT reversal unavailable ({e}); "
+                    "attribution will fall back to BPF-only"
+                )
+            except Exception:
+                pass
+
+    def _setup(self):
+        lib = ctypes.CDLL("libnetfilter_conntrack.so.3", use_errno=True)
+
+        # Declare prototypes so 64-bit pointers aren't truncated to int.
+        lib.nfct_open.restype = ctypes.c_void_p
+        lib.nfct_open.argtypes = [ctypes.c_uint8, ctypes.c_uint]
+        lib.nfct_close.argtypes = [ctypes.c_void_p]
+        lib.nfct_get_attr_u16.restype = ctypes.c_uint16
+        lib.nfct_get_attr_u16.argtypes = [ctypes.c_void_p, ctypes.c_int]
+        lib.nfct_get_attr_u32.restype = ctypes.c_uint32
+        lib.nfct_get_attr_u32.argtypes = [ctypes.c_void_p, ctypes.c_int]
+        lib.nfct_callback_register.argtypes = [
+            ctypes.c_void_p, ctypes.c_int, _CALLBACK_T, ctypes.c_void_p
+        ]
+        lib.nfct_query.restype = ctypes.c_int
+        lib.nfct_query.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_void_p]
+        lib.nfct_fd.restype = ctypes.c_int
+        lib.nfct_fd.argtypes = [ctypes.c_void_p]
+        self._lib = lib
+
+        # Verify we can actually open a conntrack handle (needs CAP_NET_ADMIN).
+        h = lib.nfct_open(_CONNTRACK, 0)
+        if not h:
+            raise OSError("nfct_open failed")
+        lib.nfct_close(h)
+
+    def _on_entry(self, _msg_type, ct, _data):
+        """Per-entry callback: capture the original source port of the entry
+        matching all of our criteria (original src IP + original dst + reply
+        port). Matching the original destination guarantees we never attribute
+        a port belonging to a different flow that reused the reply port."""
+        try:
+            lib = self._lib
+            m = self._criteria
+            if (lib.nfct_get_attr_u32(ct, _ATTR_ORIG_IPV4_SRC) == m["src_ip"]
+                    and lib.nfct_get_attr_u32(ct, _ATTR_ORIG_IPV4_DST) == m["dst_ip"]
+                    and socket.ntohs(lib.nfct_get_attr_u16(ct, _ATTR_ORIG_PORT_DST)) == m["dst_port"]
+                    and socket.ntohs(lib.nfct_get_attr_u16(ct, _ATTR_REPL_PORT_DST)) == m["repl_dport"]):
+                self._result = socket.ntohs(
+                    lib.nfct_get_attr_u16(ct, _ATTR_ORIG_PORT_SRC)
+                )
+                return _NFCT_CB_STOP
+        except Exception:
+            pass
+        return _NFCT_CB_CONTINUE
+
+    def original_src_port(
+        self,
+        client: tuple[str, int],
+        orig_dst: tuple[str, int],
+        protocol: int = IPPROTO_TCP,
+    ) -> int | None:
+        """Recover the pre-NAT source port for a transparently-proxied flow.
+
+        Args:
+            client: the accepted socket's peer address (peername) =
+                (original source IP, possibly NAT-mangled source port).
+            orig_dst: the original destination (SO_ORIGINAL_DST) =
+                (dst IP, dst port).
+
+        Returns:
+            The original source port, or None if unavailable / not found.
+        """
+        if not self.available:
+            return None
+        # Use a fresh handle per query: a DUMP that doesn't fully drain would
+        # leave stale data on a reused netlink socket and corrupt later queries.
+        handle = None
+        try:
+            handle = self._lib.nfct_open(_CONNTRACK, 0)
+            if not handle:
+                return None
+            # Enlarge the receive buffer so a full-table DUMP isn't truncated by
+            # ENOBUFS; bound the recv so a lost reply can't hang the event loop.
+            try:
+                fd = self._lib.nfct_fd(handle)
+                sock = socket.socket(fileno=fd)
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 8 * 1024 * 1024)
+                sock.settimeout(1.0)
+                sock.detach()  # the conntrack handle owns the fd
+            except Exception:
+                pass
+            self._lib.nfct_callback_register(handle, _NFCT_T_ALL, self._cb, None)
+
+            self._criteria = {
+                "src_ip": ip_to_int(client[0]),
+                "dst_ip": ip_to_int(orig_dst[0]),
+                "dst_port": orig_dst[1],
+                "repl_dport": client[1],
+            }
+            self._result = None
+            family = ctypes.c_uint32(_AF_INET)
+            self._lib.nfct_query(handle, _NFCT_Q_DUMP, ctypes.byref(family))
+            return self._result
+        except Exception:
+            return None
+        finally:
+            self._criteria = None
+            if handle:
+                try:
+                    self._lib.nfct_close(handle)
+                except Exception:
+                    pass
+
+    def close(self):
+        # Nothing persistent to release: handles are per-query.
+        pass

--- a/src/proxy/handlers/mitmproxy.py
+++ b/src/proxy/handlers/mitmproxy.py
@@ -81,9 +81,8 @@ class MitmproxyAddon:
         If no SNI, defer the policy decision to request() where we'll
         have access to the Host header after TLS decryption.
         """
-        src_port = (
-            data.context.client.peername[1] if data.context.client.peername else 0
-        )
+        peername = data.context.client.peername
+        src_port = peername[1] if peername else 0
         dst_ip, dst_port = (
             data.context.server.address
             if data.context.server.address
@@ -92,7 +91,7 @@ class MitmproxyAddon:
         sni = data.client_hello.sni
 
         if sni:
-            pid = self.bpf.lookup_pid(dst_ip, src_port, dst_port)
+            pid = self.bpf.lookup_pid_nat_aware(dst_ip, dst_port, peername)
             proc_dict = get_proc_info(pid)
 
             decision = self.enforcer.check_https(
@@ -137,7 +136,7 @@ class MitmproxyAddon:
             # No SNI — still check if dst_ip matches an insecure rule so
             # tls_start_server can skip upstream cert validation.  The full
             # policy decision is deferred to request() after MITM.
-            pid = self.bpf.lookup_pid(dst_ip, src_port, dst_port)
+            pid = self.bpf.lookup_pid_nat_aware(dst_ip, dst_port, peername)
             proc_dict = get_proc_info(pid)
             decision = self.enforcer.check_https(
                 dst_ip=dst_ip,
@@ -195,7 +194,8 @@ class MitmproxyAddon:
         TLS ClientHello had no SNI, this is where we enforce the policy using
         the Host header from the decrypted request.
         """
-        src_port = flow.client_conn.peername[1] if flow.client_conn.peername else 0
+        peername = flow.client_conn.peername
+        src_port = peername[1] if peername else 0
         dst_ip, dst_port = (
             flow.server_conn.address if flow.server_conn.address else ("unknown", 0)
         )
@@ -216,7 +216,7 @@ class MitmproxyAddon:
         if self._is_github_token(flow):
             token_kwargs["github_token"] = True
 
-        pid = self.bpf.lookup_pid(dst_ip, src_port, dst_port)
+        pid = self.bpf.lookup_pid_nat_aware(dst_ip, dst_port, peername)
         proc_dict = get_proc_info(pid)
 
         decision = self.enforcer.check_http(
@@ -295,12 +295,13 @@ class MitmproxyAddon:
     @log_errors
     def tcp_start(self, flow: tcp.TCPFlow) -> None:
         """Handle raw TCP connection - log and optionally enforce policy."""
-        src_port = flow.client_conn.peername[1] if flow.client_conn.peername else 0
+        peername = flow.client_conn.peername
+        src_port = peername[1] if peername else 0
         dst_ip, dst_port = (
             flow.server_conn.address if flow.server_conn.address else ("unknown", 0)
         )
 
-        pid = self.bpf.lookup_pid(dst_ip, src_port, dst_port)
+        pid = self.bpf.lookup_pid_nat_aware(dst_ip, dst_port, peername)
         proc_dict = get_proc_info(pid)
 
         decision = self.enforcer.check_tcp(
@@ -463,7 +464,8 @@ class MitmproxyAddon:
         - Host process with a custom/embedded trust store
         - Certificate pinning
         """
-        src_port = data.context.client.peername[1] if data.context.client.peername else 0
+        peername = data.context.client.peername
+        src_port = peername[1] if peername else 0
         dst_ip, dst_port = (
             data.context.server.address
             if data.context.server.address
@@ -471,7 +473,7 @@ class MitmproxyAddon:
         )
         sni = data.context.client.sni
 
-        pid = self.bpf.lookup_pid(dst_ip, src_port, dst_port)
+        pid = self.bpf.lookup_pid_nat_aware(dst_ip, dst_port, peername)
         proc_dict = get_proc_info(pid)
 
         decision = self.enforcer.check_https(

--- a/src/setup/deps.sha256
+++ b/src/setup/deps.sha256
@@ -4,6 +4,7 @@
 d588b5127609fe5bf98f0765d3a75a5eaf61a2d79c568d8b1ddf9fc52271db2b  https://archive.ubuntu.com/ubuntu/pool/main/libn/libnfnetlink/libnfnetlink-dev_1.0.2-2build1_amd64.deb
 3393e6d3d1579968de966f102179f3720cef6b02ae71cb86fb89563fdcb969f6  https://archive.ubuntu.com/ubuntu/pool/universe/libn/libnetfilter-queue/libnetfilter-queue1_1.0.5-4build1_amd64.deb
 565072d702f7c4ceca06832d2d7dcbd0e6c29aa5ee9349b92ea49460f1d2accc  https://archive.ubuntu.com/ubuntu/pool/universe/libn/libnetfilter-queue/libnetfilter-queue-dev_1.0.5-4build1_amd64.deb
+6d32a4c4618eb7d6c0d989591d28637a9acdfa86dfe22e42e9ac9cc25d882a97  https://archive.ubuntu.com/ubuntu/pool/main/libn/libnetfilter-conntrack/libnetfilter-conntrack3_1.0.9-6build1_amd64.deb
 
 # Installers
 f0a9da374c8eee3989acba54839184a053f94b9fbe55cf8505bcf0b5fe45e418  https://astral.sh/uv/0.10.2/install.sh

--- a/src/setup/generate-deps.py
+++ b/src/setup/generate-deps.py
@@ -18,6 +18,8 @@ APT_PACKAGES = [
     "libnfnetlink-dev",
     "libnetfilter-queue1",
     "libnetfilter-queue-dev",
+    # NAT reversal for PID attribution (conntrack source-port un-mangling).
+    "libnetfilter-conntrack3",
 ]
 
 # GitHub releases to fetch install scripts from

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,12 +5,18 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-# Skip handler tests when proxy extra dependencies (mitmproxy, etc.) are missing.
+# Skip tests needing proxy extra dependencies (mitmproxy, tinybpf, ...) when absent.
 collect_ignore_glob = []
+collect_ignore = []
 try:
     import mitmproxy  # noqa: F401
 except ImportError:
     collect_ignore_glob.append("test_handler_*.py")
+try:
+    import tinybpf  # noqa: F401
+except ImportError:
+    # BPFState (proxy.bpf) imports tinybpf at module load.
+    collect_ignore.append("test_nat_reversal.py")
 
 from proxy.policy.enforcer import Decision, Verdict
 
@@ -23,6 +29,9 @@ class MockBPFState:
         self.dns_cache = {}
 
     def lookup_pid(self, dst_ip, src_port, dst_port, protocol=6):
+        return self._pid
+
+    def lookup_pid_nat_aware(self, dst_ip, dst_port, peername, protocol=6):
         return self._pid
 
 

--- a/tests/test_conntrack.py
+++ b/tests/test_conntrack.py
@@ -1,0 +1,36 @@
+"""Tests for the conntrack NAT-reversal module (fail-safe behavior).
+
+The real netlink query path needs root + a live connection, so these focus
+on the contract that matters operationally: the module never raises, and
+degrades to "unavailable -> None" when the library can't be used.
+"""
+
+from proxy import conntrack
+from proxy.conntrack import ConntrackReverser
+
+
+def test_unavailable_when_library_missing(monkeypatch):
+    def boom(*a, **k):
+        raise OSError("no library")
+
+    monkeypatch.setattr(conntrack.ctypes, "CDLL", boom)
+    r = ConntrackReverser()
+    assert r.available is False
+    # Queries must be safe no-ops when unavailable.
+    assert r.original_src_port(("127.0.0.1", 8080), ("10.0.0.1", 9999)) is None
+    r.close()
+
+
+def test_query_never_raises_on_real_or_unavailable_lib():
+    # Whether or not the lib/handle is usable in this environment, a query
+    # must return an int or None and never propagate an exception.
+    r = ConntrackReverser()
+    result = r.original_src_port(("127.0.0.1", 8080), ("10.255.255.254", 65000))
+    assert result is None or isinstance(result, int)
+    r.close()
+
+
+def test_close_is_idempotent():
+    r = ConntrackReverser()
+    r.close()
+    r.close()  # must not raise

--- a/tests/test_nat_reversal.py
+++ b/tests/test_nat_reversal.py
@@ -1,0 +1,115 @@
+"""Tests for NAT-aware PID lookup (conntrack source-port reversal).
+
+These exercise the BPFState.lookup_pid_nat_aware logic with a fake BPF map
+and a fake conntrack reverser — no kernel / netlink required.
+"""
+
+from proxy.bpf import BPFState, ConnKeyV4
+from proxy.utils import ip_to_int, IPPROTO_TCP
+
+
+class FakeMap:
+    """In-memory stand-in for the typed BPF map keyed by ConnKeyV4."""
+
+    def __init__(self):
+        self._d = {}
+
+    def put(self, dst_ip, src_port, dst_port, pid, protocol=IPPROTO_TCP):
+        self._d[(ip_to_int(dst_ip), src_port, dst_port, protocol)] = pid
+
+    def get(self, key: ConnKeyV4):
+        return self._d.get((key.dst_ip, key.src_port, key.dst_port, key.protocol))
+
+
+class FakeReverser:
+    """Stand-in for ConntrackReverser returning a preset original port."""
+
+    def __init__(self, orig_port=None):
+        self.orig_port = orig_port
+        self.calls = []
+
+    def original_src_port(self, client, orig_dst, protocol=IPPROTO_TCP):
+        self.calls.append((client, orig_dst, protocol))
+        return self.orig_port
+
+
+def _bpf(fake_map, reverser=None):
+    b = BPFState.__new__(BPFState)  # bypass __init__ (no real BPF load)
+    b.map_v4 = fake_map
+    b.conntrack = reverser
+    return b
+
+
+def test_direct_hit_no_conntrack_needed():
+    m = FakeMap()
+    m.put("140.82.113.3", 41000, 443, pid=1234)
+    rev = FakeReverser(orig_port=41000)
+    bpf = _bpf(m, rev)
+
+    # peername src_port matches what was recorded -> direct hit, no reversal
+    pid = bpf.lookup_pid_nat_aware(
+        "140.82.113.3", 443, peername=("10.1.0.5", 41000),
+    )
+    assert pid == 1234
+    assert rev.calls == []  # conntrack not consulted on a hit
+
+
+def test_nat_remapped_recovered_via_conntrack():
+    m = FakeMap()
+    # kprobe recorded the ORIGINAL port 41000
+    m.put("140.82.113.3", 41000, 443, pid=4321)
+    # conntrack maps the connection back to original port 41000
+    rev = FakeReverser(orig_port=41000)
+    bpf = _bpf(m, rev)
+
+    # proxy sees the MANGLED port 8957 -> direct lookup misses -> reversal hits
+    pid = bpf.lookup_pid_nat_aware(
+        "140.82.113.3", 443, peername=("10.1.0.5", 8957),
+    )
+    assert pid == 4321
+    assert rev.calls == [(("10.1.0.5", 8957), ("140.82.113.3", 443), IPPROTO_TCP)]
+
+
+def test_miss_with_no_conntrack_entry_returns_none():
+    m = FakeMap()
+    m.put("140.82.113.3", 41000, 443, pid=4321)
+    rev = FakeReverser(orig_port=None)  # conntrack has no entry
+    bpf = _bpf(m, rev)
+
+    pid = bpf.lookup_pid_nat_aware(
+        "140.82.113.3", 443, peername=("10.1.0.5", 8957),
+    )
+    assert pid is None
+
+
+def test_reverser_returns_same_port_does_not_loop():
+    # If conntrack returns the same (unmangled) port, we must not re-query.
+    m = FakeMap()  # empty -> genuine miss
+    rev = FakeReverser(orig_port=8957)
+    bpf = _bpf(m, rev)
+
+    pid = bpf.lookup_pid_nat_aware(
+        "140.82.113.3", 443, peername=("10.1.0.5", 8957),
+    )
+    assert pid is None
+
+
+def test_no_conntrack_reverser_falls_back_to_miss():
+    m = FakeMap()
+    bpf = _bpf(m, reverser=None)
+    pid = bpf.lookup_pid_nat_aware(
+        "140.82.113.3", 443, peername=("10.1.0.5", 8957),
+    )
+    assert pid is None
+
+
+def test_no_peername_skips_reversal():
+    m = FakeMap()
+    m.put("140.82.113.3", 41000, 443, pid=4321)
+    rev = FakeReverser(orig_port=41000)
+    bpf = _bpf(m, rev)
+
+    # Without a peername there's nothing to look up or reverse.
+    pid = bpf.lookup_pid_nat_aware("140.82.113.3", 443, peername=None)
+    assert pid is None
+    assert rev.calls == []


### PR DESCRIPTION
## Problem

Intermittent attribution failures in production (notably during docker image pulls): a small fraction of connections get **no PID attribution**, and because `for_runner` stamps `cgroup=` on every rule, an unattributed connection matches nothing and is **wrongly blocked** in enforcement mode.

## Root cause (investigated and confirmed on a runner)

The `tcp_connect` kprobe records the 4-tuple with the **original (pre-NAT)** source port. The transparent proxy sees connections **after** iptables `REDIRECT`, whose DNAT collapses every destination onto the single proxy socket (`127.0.0.1:8080`). When two concurrent connections reuse an ephemeral source port to **different** destinations, their reply tuples collide and **netfilter remaps one's source port**. The proxy then looks up the BPF map with the remapped port the kprobe never recorded → miss.

Ruled out (with instrumentation): not an unhandled `bpf_map_update_elem` failure (`update_FAIL=0`), not a guard early-return, not LRU eviction (swapping to a non-evicting `HASH` map gave the same miss rate). The smoking gun: on a miss the looked-up source port is absent from the entire map though thousands of *other* ports to the same destination are present, and the missed ports fall **outside the ephemeral range** — the signature of NAT remapping.

## Fix

On a BPF miss, ask conntrack — the only component that knows the NAT mapping — for the connection's **original source port**, then retry the lookup. The entry is identified by the original source IP, the original destination (`SO_ORIGINAL_DST`), and the reply-tuple destination port (the mangled port the proxy sees).

Matching the **original destination** is what makes this safe: a remapped reply port can be shared with an unrelated flow, but only one entry has that reply port *and* our destination — so we can never attribute a port from a different flow. Worst case is no match → no attribution, exactly as before this change.

Key implementation details:
- **Fresh conntrack handle per query.** A DUMP that doesn't fully drain leaves stale data on a reused netlink socket and corrupts later queries — this manifested as most lookups silently failing under load.
- **Fully fail-safe.** If `libnetfilter_conntrack` is unavailable or any query fails, attribution falls back to today's BPF-only behavior.
- Adds `libnetfilter-conntrack3` to the dependency manifest.

Why not TPROXY (which would avoid NAT entirely)? mitmproxy's transparent mode is REDIRECT-based, loop prevention here is cgroup-based, and TPROXY's required policy routing would collide with the Tailscale/WireGuard scenario this action supports. (See investigation discussion.)

## Validation

- 990 + 67 unit tests pass (new: `test_nat_reversal.py`, `test_conntrack.py`).
- New `test-attribution-stress.yml` deterministically triggers source-port mangling by binding socket pairs to a shared source port toward different destinations (no box saturation), and confirms **every** mangled connection is re-attributed: `69 mangled, 0 unattributed`.

## Dependency

Stacked on #180 (runner exe-path fix), which the proxy needs to start on current runner images. Base will retarget to `main` once #180 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)