### PR TITLE
Make runner-context detection robust to runner image updates

### DIFF
--- a/src/proxy/policy/defaults.py
+++ b/src/proxy/policy/defaults.py
@@ -5,12 +5,19 @@ to function properly. They can be auto-included with `include: defaults` or
 via the enforcer's `include_defaults=True` option.
 """
 
-from .gha import RUNNER_CGROUP
+from .gha import RUNNER_CGROUP, runner_cgroup
 from .types import DefaultContext
 
-# Defaults for GitHub Actions runner (includes cgroup constraint)
-# This ensures all rules only match connections from the runner process tree
+# Defaults for GitHub Actions runner (includes cgroup constraint).
+# This ensures all rules only match connections from the runner process tree.
+# Static default (back-compat / tests); the proxy uses runner_defaults() so it
+# picks up the cgroup derived at startup.
 RUNNER_DEFAULTS = DefaultContext(attrs={"cgroup": RUNNER_CGROUP})
+
+
+def runner_defaults() -> DefaultContext:
+    """Runner default context using the effective (possibly derived) cgroup."""
+    return DefaultContext(attrs={"cgroup": runner_cgroup()})
 
 # Default rules for GitHub-hosted runners
 # These are automatically applied unless disabled

--- a/src/proxy/policy/enforcer.py
+++ b/src/proxy/policy/enforcer.py
@@ -10,7 +10,7 @@ from enum import Enum
 from typing import Protocol
 from urllib.parse import urlparse
 
-from .defaults import RUNNER_DEFAULTS, get_defaults
+from .defaults import get_defaults, runner_defaults
 from .dns_cache import DNSIPCache
 from .matcher import ConnectionEvent, PolicyMatcher
 from .parser import parse_github_repository, substitute_placeholders
@@ -514,5 +514,5 @@ class PolicyEnforcer:
 
         if include_defaults:
             policy_text = get_defaults() + "\n" + policy_text
-        matcher = PolicyMatcher(policy_text, defaults=RUNNER_DEFAULTS)
+        matcher = PolicyMatcher(policy_text, defaults=runner_defaults())
         return cls(matcher, dns_cache, audit_mode)

--- a/src/proxy/policy/gha.py
+++ b/src/proxy/policy/gha.py
@@ -9,9 +9,28 @@ of any specific action. They're used for:
 import os
 import re
 
-# Cgroup path for processes in the runner's process tree
-# Used to distinguish runner processes from Docker containers, Azure agent, etc.
-RUNNER_CGROUP = "/system.slice/hosted-compute-agent.service"
+# Cgroup path for processes in the runner's process tree, used to distinguish
+# runner processes from Docker containers, the Azure agent, etc.
+#
+# This is only a *fallback*: at startup the proxy derives the actual cgroup
+# from the live Runner.Worker (see validate_runner_environment) so a rename of
+# the hosted-compute-agent service adapts automatically instead of silently
+# breaking every rule. Read the effective value via runner_cgroup().
+DEFAULT_RUNNER_CGROUP = "/system.slice/hosted-compute-agent.service"
+# Back-compat alias for importers/tests that want the static default.
+RUNNER_CGROUP = DEFAULT_RUNNER_CGROUP
+
+_runner_cgroup = DEFAULT_RUNNER_CGROUP
+
+
+def runner_cgroup() -> str:
+    """Effective runner cgroup (derived at startup; falls back to the default)."""
+    return _runner_cgroup
+
+
+def _set_runner_cgroup(value: str) -> None:
+    global _runner_cgroup
+    _runner_cgroup = value
 
 # Runner exe paths vary by installation method: "cached", "extracted", a
 # version directory like "2.331.0", or nested like "cached/2.334.0".
@@ -29,55 +48,79 @@ def is_node24(exe: str) -> bool:
     return _NODE24_RE.match(exe) is not None
 
 
-def validate_runner_environment() -> list[str]:
-    """Validate that we're running under the expected GitHub runner process tree.
+def check_runner_ancestry(exe_paths: list[str]) -> list[str]:
+    """Structural sanity check on a process ancestry (self -> outward).
 
-    Checks process ancestry for Runner.Worker and node24 at expected positions.
-    Returns list of error messages (empty if all valid).
+    Position-independent (unlike asserting fixed indices, which broke on runner
+    image updates): we only require that Runner.Worker and the node24 action
+    runtime are both present and that node24 is a *descendant* of Runner.Worker
+    (i.e. appears earlier in the self-outward list). This survives wrappers
+    being added to or removed from the runner process tree.
 
-    Expected ancestry (from self outward):
-      [0] python3      <- proxy
-      [1] bash
-      [2] bash
-      [3] sudo
-      [4] node24       <- action runtime
-      [5] Runner.Worker <- step spawner
-      [6] Runner.Listener
-      [7] hosted-compute-agent
+    Returns a list of error messages (empty if the structure looks right).
     """
-    # Lazy import to avoid circular dependency (proc.py imports from gha.py)
-    from proxy.proc import get_process_ancestry
-
-    errors = []
-    ancestry = get_process_ancestry(os.getpid(), max_depth=10)
-    exe_paths = [exe for _, exe in ancestry]
-
-    # Find positions by pattern match
     node24_idx = next((i for i, exe in enumerate(exe_paths) if is_node24(exe)), -1)
     worker_idx = next((i for i, exe in enumerate(exe_paths) if is_runner_worker(exe)), -1)
 
-    if node24_idx != 4:
-        actual_at_4 = exe_paths[4] if len(exe_paths) > 4 else "<missing>"
+    errors = []
+    if worker_idx < 0:
+        errors.append(f"Runner.Worker not found in ancestry: {exe_paths}")
+    if node24_idx < 0:
+        errors.append(f"node24 action runtime not found in ancestry: {exe_paths}")
+    if worker_idx >= 0 and node24_idx >= 0 and node24_idx >= worker_idx:
         errors.append(
-            f"node24 at index {node24_idx}, expected 4"
-            f" (index 4 is {actual_at_4}; ancestry: {exe_paths})"
+            f"node24 (idx {node24_idx}) should be a descendant of Runner.Worker "
+            f"(idx {worker_idx}); ancestry: {exe_paths}"
         )
-
-    if worker_idx != 5:
-        actual_at_5 = exe_paths[5] if len(exe_paths) > 5 else "<missing>"
-        errors.append(
-            f"Runner.Worker at index {worker_idx}, expected 5"
-            f" (index 5 is {actual_at_5}; ancestry: {exe_paths})"
-        )
-
-    # Check cgroup of Runner.Worker (proxy itself runs in its own scope)
-    if worker_idx >= 0:
-        from proxy.proc import get_cgroup_path
-        worker_pid = ancestry[worker_idx][0]
-        worker_cgroup = get_cgroup_path(worker_pid)
-        if worker_cgroup != RUNNER_CGROUP:
-            errors.append(
-                f"Runner.Worker cgroup: got {worker_cgroup}, expected {RUNNER_CGROUP}"
-            )
-
     return errors
+
+
+def validate_runner_environment() -> list[str]:
+    """Confirm the proxy can attribute connections to the runner, and derive
+    the runner cgroup. Returns a list of error messages (empty if valid).
+
+    Rather than asserting a fixed process-tree shape (which is brittle across
+    runner updates), this validates the *capability* the security model relies
+    on: it derives the runner cgroup from the live Runner.Worker, then runs the
+    exact trusted-env walk that authenticates the control socket and confirms it
+    recovers this action's own GITHUB_ACTION_REPOSITORY. If that works, the tree
+    shape doesn't matter. A structural check is used only as a fallback when the
+    functional self-test can't run (e.g. no GITHUB_ACTION_REPOSITORY, as on some
+    forks).
+    """
+    # Lazy import to avoid a circular dependency (proc.py imports from gha.py).
+    from proxy.proc import (
+        get_process_ancestry,
+        get_cgroup_path,
+        get_trusted_github_env,
+    )
+
+    ancestry = get_process_ancestry(os.getpid(), max_depth=10)
+    exe_paths = [exe for _, exe in ancestry]
+    node24_idx = next((i for i, exe in enumerate(exe_paths) if is_node24(exe)), -1)
+    worker_idx = next((i for i, exe in enumerate(exe_paths) if is_runner_worker(exe)), -1)
+
+    # Derive the runner cgroup from Runner.Worker so the rest of the proxy
+    # (is_runner_process + the cgroup= injected on every rule) adapts to a
+    # service rename instead of breaking.
+    if worker_idx >= 0:
+        worker_cgroup = get_cgroup_path(ancestry[worker_idx][0])
+        if worker_cgroup:
+            _set_runner_cgroup(worker_cgroup)
+
+    # Functional self-test: the trusted-env walk (the control-socket auth
+    # mechanism) must recover our own action repo from the action runtime.
+    expected_repo = os.environ.get("GITHUB_ACTION_REPOSITORY", "")
+    if expected_repo and node24_idx >= 0 and worker_idx >= 0:
+        trusted = get_trusted_github_env(ancestry[node24_idx][0])
+        got_repo = trusted.get("GITHUB_ACTION_REPOSITORY", "")
+        if got_repo == expected_repo:
+            return []  # capability confirmed; tree shape is adequate by definition
+        return [
+            f"trusted-env self-test failed: recovered "
+            f"GITHUB_ACTION_REPOSITORY={got_repo!r}, expected {expected_repo!r} "
+            f"(cgroup={runner_cgroup()}; ancestry: {exe_paths})"
+        ]
+
+    # Couldn't self-test (no repo / missing process) -> structural fallback.
+    return check_runner_ancestry(exe_paths)

--- a/src/proxy/proc.py
+++ b/src/proxy/proc.py
@@ -7,7 +7,7 @@ import re
 import socket
 from pathlib import Path
 
-from proxy.policy.gha import RUNNER_CGROUP, is_runner_worker
+from proxy.policy.gha import is_runner_worker, runner_cgroup
 
 
 # =============================================================================
@@ -197,7 +197,7 @@ def get_process_ancestry(pid: int, max_depth: int = 10) -> list[tuple[int, str]]
 def is_runner_process(pid: int) -> bool:
     """Check if process is in the runner cgroup (quick filter)."""
     cgroup = get_cgroup_path(pid)
-    return cgroup == RUNNER_CGROUP if cgroup else False
+    return cgroup == runner_cgroup() if cgroup else False
 
 
 def find_trusted_github_pids(pid: int) -> list[int]:

--- a/tests/test_gha.py
+++ b/tests/test_gha.py
@@ -2,7 +2,59 @@
 
 import pytest
 
-from proxy.policy.gha import is_node24, is_runner_worker
+from proxy.policy.gha import (
+    DEFAULT_RUNNER_CGROUP,
+    check_runner_ancestry,
+    is_node24,
+    is_runner_worker,
+    runner_cgroup,
+)
+
+_BASE = "/home/runner/actions-runner/cached/2.334.0/"
+_NODE24 = _BASE + "externals/node24/bin/node"
+_WORKER = _BASE + "bin/Runner.Worker"
+
+
+def test_runner_cgroup_defaults_to_constant():
+    # Without startup derivation, the effective cgroup is the static default.
+    assert runner_cgroup() == DEFAULT_RUNNER_CGROUP
+
+
+def test_ancestry_ok_for_current_layout():
+    # self -> outward; node24 (action runtime) is a descendant of Runner.Worker.
+    exe_paths = [
+        "/usr/bin/python3.12", "/usr/bin/bash", "/usr/bin/bash", "/usr/bin/sudo",
+        _NODE24, _WORKER,
+        _BASE + "bin/Runner.Listener", "/opt/hca/hosted-compute-agent",
+    ]
+    assert check_runner_ancestry(exe_paths) == []
+
+
+def test_ancestry_ok_when_wrappers_shift_indices():
+    # Extra wrapper processes shift positions — the OLD index assertions broke
+    # here; relative-order must still accept it.
+    exe_paths = [
+        "/usr/bin/python3.12", "/usr/bin/bash", "/usr/bin/some-wrapper",
+        "/usr/bin/bash", "/usr/bin/sudo", _NODE24, _WORKER,
+        _BASE + "bin/Runner.Listener",
+    ]
+    assert check_runner_ancestry(exe_paths) == []
+
+
+def test_ancestry_rejects_missing_runner_worker():
+    errs = check_runner_ancestry(["/usr/bin/python3.12", _NODE24, "/usr/bin/bash"])
+    assert any("Runner.Worker not found" in e for e in errs)
+
+
+def test_ancestry_rejects_missing_node24():
+    errs = check_runner_ancestry(["/usr/bin/python3.12", "/usr/bin/bash", _WORKER])
+    assert any("node24" in e and "not found" in e for e in errs)
+
+
+def test_ancestry_rejects_node24_not_descendant_of_worker():
+    # node24 appearing *outside* Runner.Worker (later in self-outward list) is wrong.
+    errs = check_runner_ancestry(["/usr/bin/python3.12", _WORKER, _NODE24])
+    assert any("descendant of Runner.Worker" in e for e in errs)
 
 
 # Layouts observed on GitHub-hosted runners over time


### PR DESCRIPTION
## Why

The startup check asserted a **fixed process-tree shape** (node24 at ancestry index 4, Runner.Worker at index 5) and a **hardcoded runner cgroup**. Runner image updates that reshape the tree or rename the service broke the proxy *hard* — it `sys.exit`s and fails the workflow — even though attribution would still have worked. This is the fragility that bit us twice recently (exact exe paths, then nested version dirs).

## What

Three changes, all in the **startup detection**. The control-socket trust anchor in `proc.py` — *trust only Runner.Worker's direct child's environ* — is **untouched**; the brittle index checks were never part of that, they were a startup canary.

1. **Relative-order structural check** instead of fixed indices: require Runner.Worker and node24 present, with node24 a *descendant* of Runner.Worker. Survives wrappers being added/removed (`check_runner_ancestry`, unit-tested).
2. **Derive the runner cgroup from the live Runner.Worker** instead of hardcoding it. A service rename now adapts automatically, and it defuses a fragility multiplier — the cgroup is stamped on *every* rule, so one stale string would otherwise block all traffic. As a bonus it's self-consistent: `is_runner_process` compares `/proc` cgroups via the *same* function used to derive it, removing any format-mismatch assumption.
3. **Functional self-test over structure assertion**: run the actual trusted-env walk (the control-socket auth mechanism) and confirm it recovers this action's own `GITHUB_ACTION_REPOSITORY`. If the capability works, tree shape is irrelevant; the structural check is only a fallback when the self-test can't run.

Failure behavior is unchanged (errors still abort startup). Making detection failures *degrade-with-warning* instead of hard-fail is a separate, follow-up change.

## Validation

- 987 + proxy-extra unit tests pass (new `check_runner_ancestry` / cgroup tests in `test_gha.py`).
- Full integration suite green on `test`: baseline (proxy starts → self-test passes), transparent-proxy, Docker attribution (derived cgroup), **permissions-analysis** and **Tailscale** (trusted-env walk). The one failure was the known `expired.badssl.com` 502 flake (unrelated; rerun green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)