### PR TITLE
Add scheduled runner/kernel compatibility canary

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,66 @@
+name: Canary (runner / kernel compatibility)
+
+# Early warning that a GitHub-hosted runner image, kernel, or BTF update hasn't
+# broken the eBPF load+attach or core enforcement — BEFORE users hit it.
+#
+# Starting the proxy loads and attaches *every* BPF program against the live
+# kernel, so a verifier rejection, a removed/renamed helper, or a BTF/CO-RE
+# change makes this job go red. The smoke test then confirms enforcement still
+# works end to end. The fingerprint step records what we ran against so a
+# failure tells you which layer moved (kernel / BTF / our pinned loader).
+#
+# Runs the released action (@main) on the latest runner image, on a schedule.
+
+on:
+  schedule:
+    - cron: '0 6 * * *'  # daily, 06:00 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: canary
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 6
+    steps:
+      - name: Runner / kernel / BTF fingerprint
+        run: |
+          echo "image:  ${ImageOS:-?} ${ImageVersion:-?}"
+          echo "kernel: $(uname -r)"
+          # /sys/kernel/btf/vmlinux is world-readable (no sudo); fingerprint it
+          # so a BTF/CO-RE change is visible when this canary goes red.
+          btf=$(sha256sum /sys/kernel/btf/vmlinux 2>/dev/null | cut -c1-16)
+          echo "btf:    ${btf:-unavailable}"
+
+      - name: Start egress filter (enforcement — loads + attaches all BPF)
+        uses: gregclermont/egress-filter@main
+        with:
+          policy: |
+            github.com
+
+      - name: Smoke test — allowed flows, disallowed is blocked
+        run: |
+          allowed=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 https://github.com/ || echo 000)
+          echo "github.com  (allowed)    -> $allowed"
+          if [ "$allowed" -lt 200 ] || [ "$allowed" -ge 400 ]; then
+            echo "::error::allowed host github.com returned $allowed (expected 2xx/3xx) — proxy/BPF likely degraded"
+            exit 1
+          fi
+          if curl -s -o /dev/null --max-time 20 https://example.com/; then
+            echo "::error::disallowed host example.com was NOT blocked — enforcement is off"
+            exit 1
+          fi
+          echo "example.com (disallowed) -> blocked as expected"
+
+      - name: Proxy log + loader version (diagnostics)
+        if: always()
+        run: |
+          venv=/home/runner/work/_actions/gregclermont/egress-filter/main/.venv/bin/python
+          [ -x "$venv" ] && "$venv" -c "import tinybpf; print('tinybpf libbpf:', tinybpf.libbpf_version)" 2>/dev/null || true
+          echo "=== proxy.log ==="
+          cat "${{ runner.temp }}/proxy.log" 2>/dev/null || echo "No proxy log (proxy may have failed to start)"


### PR DESCRIPTION
## Why

Most of this project's fragility is to **GitHub runner image / kernel / BTF updates** — the moving parts GitHub controls and doesn't announce (it's bitten us twice on the process-tree, and the eBPF load is exposed to verifier/BTF/helper changes). The goal is to *react rarely, and early* — catch breakage in our own CI within a day of a runner rollout instead of from a user's broken-workflow issue.

## What

A scheduled canary (`ubuntu-latest`, daily + manual dispatch) that runs the released action (`@main`) and:

1. **Fingerprints** the runner — `ImageOS/Version`, `uname -r`, the `/sys/kernel/btf/vmlinux` hash, and tinybpf's `libbpf_version` — so when it goes red you can see *which layer moved* (kernel / BTF / our pinned loader).
2. **Starts the proxy**, which loads and attaches *every* BPF program against the live kernel. This single act catches a verifier rejection, a removed/renamed helper (the `bpf_sk_fullsock` lesson), or a BTF/CO-RE change — regardless of source.
3. **Smoke-tests enforcement**: an allowlisted host must flow (2xx/3xx) and a non-allowlisted host must be blocked.

It also naturally flags the "a runner update needs a code change" case loudly — e.g. when `ubuntu-latest` rolls to a new major, the action's `ImageOS=ubuntu24` gate fails at the start step and the canary goes red.

This complements, rather than replaces, the pinned-dependency story: tinybpf/libbpf is pinned from our own index (it only moves when we bump it), so there's nothing to "watch" there — the canary covers the layer that moves on its own.

## Validation

Ran on a real runner (via a temporary `push:[test]` trigger, since removed): **green** — proxy started (all BPF loaded+attached on kernel `6.17.0-1018-azure`), allowed host flowed, disallowed host blocked. The BTF fingerprint read is verified against a world-readable `/sys/kernel/btf/vmlinux`.

Note: `schedule` only fires once this is on the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)